### PR TITLE
fixed unclean z3 solver object which has lead to wrong sat/unsat answers

### DIFF
--- a/src/main/gov/nasa/jpf/symbc/numeric/PCParser.java
+++ b/src/main/gov/nasa/jpf/symbc/numeric/PCParser.java
@@ -1040,7 +1040,15 @@ getExpression(stoex.value)), newae));
         return true;
     }
 
-  // result is in pb
+  /**
+   * Merges the given path condition with the given ProblemGeneral object (i.e. the solver).
+   * Normally the merging means only adding the assertions from the path condition to the 
+   * solver's internal representation.
+   * 
+   * @param pc PathCondition
+   * @param pbtosolve ProblemGeneral
+   * @return the merged ProblemGener al object; NULL if problem is unsat
+   */
   public static ProblemGeneral parse(PathCondition pc, ProblemGeneral pbtosolve) {
     pb=pbtosolve;
 


### PR DESCRIPTION
We experienced the problem that sometimes during symbolic analysis the solver with a satisfiable path condition resulted in an UNSAT answer. The problem was/is contraint solver specific, because it was working for Coral (here the answer was SAT), but for z3 (which we prioritize in our work) answered with UNSAT. We there able to bypass the problem by calling "pc.simplify()" always twice and use the second answer, which was correct. We observed that the z3 solver object was having unwanted assertions during the first solver call, whereas the during the second solver call the z3 solver object was having only the assertions specific for the given path condition. So it seemed the the cleanup(), which is needed for the z3 solver, was not working properly. Here the actual bug:

The cleanup() method in the class SymbolicConstraintGeneral assumes that the pb object is **not** null:

    public void cleanup() {
        if (pb instanceof ProblemCVC3) {
            ((ProblemCVC3) pb).cleanup();
        } else if (pb instanceof ProblemCoral) {
            ((ProblemCoral) pb).cleanup();
        } else if (pb instanceof ProblemZ3) {
            ((ProblemZ3) pb).cleanup();
        } else if (pb instanceof ProblemZ3BitVector) {
            ((ProblemZ3BitVector) pb).cleanup();
        } else if (pb instanceof ProblemZ3Optimize) {
            ((ProblemZ3Optimize) pb).cleanup();
        }
    }

If the object is null, then none of the specified cleanups will be triggered. Unfortunately, the method SymbolicConstraintGeneral.isSatisfiable(PathCondition) uses the result from PCParser.parse(pc, pb) to override the pc object **without** checking for a null result:

`pb = PCParser.parse(pc, pb);`

The null value seems to mean a early unsat notification, which can be trivially detected during the parsing of the path condition (we extended here the documentation of the parse-method). Our solution is then to temporarily store the result from PCParser.parse(pc, pb) and only override pb for an non-null return value. As a result, the pb object always includes the last solver, and the cleanup can work correctly.