### PR TITLE
Fix call on null object, align SPF with JPF

### DIFF
--- a/src/main/gov/nasa/jpf/symbc/bytecode/INVOKEVIRTUAL.java
+++ b/src/main/gov/nasa/jpf/symbc/bytecode/INVOKEVIRTUAL.java
@@ -19,6 +19,7 @@ package gov.nasa.jpf.symbc.bytecode;
 
 import gov.nasa.jpf.vm.ClassInfo;
 import gov.nasa.jpf.vm.Instruction;
+port gov.nasa.jpf.vm.MJIEnv;
 import gov.nasa.jpf.vm.MethodInfo;
 import gov.nasa.jpf.vm.ThreadInfo;
 
@@ -34,7 +35,7 @@ public class INVOKEVIRTUAL extends gov.nasa.jpf.jvm.bytecode.INVOKEVIRTUAL {
 	public Instruction execute( ThreadInfo th) {
 		int objRef = th.getCalleeThis(getArgSize());
 
-	    if (objRef == -1) {
+	    if (objRef == -1 || objRef == MJIEnv.NULL) {
 	      lastObj = -1;
 	      return th.createAndThrowException("java.lang.NullPointerException", "Calling '" + mname + "' on null object");
 	    }


### PR DESCRIPTION
Fix for catching null pointer exceptions when calling a method on a null object. This is to fix one of the svcomp cases.