### PR TITLE
Z3 and floating points: check useFpForReals when translating gt and lt expressions

### DIFF
--- a/src/main/gov/nasa/jpf/symbc/numeric/solvers/ProblemZ3.java
+++ b/src/main/gov/nasa/jpf/symbc/numeric/solvers/ProblemZ3.java
@@ -354,7 +354,11 @@ public class ProblemZ3 extends ProblemGeneral {
 
 	public Object lt(Object exp1, Object exp2){
 		try{
-			return  ctx.mkLt((ArithExpr)exp1,(ArithExpr)exp2);
+			if (useFpForReals) {
+			    return  ctx.mkFPLt((FPExpr)exp1,(FPExpr)exp2);
+			} else {
+				return  ctx.mkLt((ArithExpr)exp1,(ArithExpr)exp2);
+			}
 		} catch (Exception e) {
 			e.printStackTrace();
 			throw new RuntimeException("## Error Z3: Exception caught in Z3 JNI: \n" + e);
@@ -405,7 +409,11 @@ public class ProblemZ3 extends ProblemGeneral {
 
 	public Object gt(Object exp1, Object exp2){
 		try{
-			return  ctx.mkGt((ArithExpr)exp1,(ArithExpr)exp2);
+			if (useFpForReals) {
+	            return  ctx.mkFPGt((FPExpr)exp1,(FPExpr)exp2);
+		    } else {
+			    return  ctx.mkGt((ArithExpr)exp1,(ArithExpr)exp2);
+		    }
 		} catch (Exception e) {
 			e.printStackTrace();
 			throw new RuntimeException("## Error Z3: Exception caught in Z3 JNI: \n" + e);


### PR DESCRIPTION
If this isn't checked and handled, then +symbolic.dp=z3 +symbolic.fp=true fails on arithmetic comparisons with a typecast exception (java.lang.ClassCastException: com.microsoft.z3.FPExpr cannot be cast to com.microsoft.z3.ArithExpr)