### PR TITLE
Update ConcreteExecutionListener.java

### DIFF
--- a/src/main/gov/nasa/jpf/symbc/concolic/ConcreteExecutionListener.java
+++ b/src/main/gov/nasa/jpf/symbc/concolic/ConcreteExecutionListener.java
@@ -64,8 +64,8 @@ public class ConcreteExecutionListener extends PropertyListenerAdapter {
 	public void instructionExecuted(VM vm, ThreadInfo currentThread, Instruction nextInstruction, Instruction executedInstruction) {
 
 		Instruction lastInsn =  executedInstruction;
-		MethodInfo mi = executedInstruction.getMethodInfo();
 		if(lastInsn != null && lastInsn instanceof JVMInvokeInstruction) {
+			MethodInfo mi =((JVMInvokeInstruction)lastInsn).getInvokedMethod();
 			boolean foundAnote = checkConcreteAnnotation(mi);
 			if(foundAnote) {
 				ThreadInfo ti = vm.getCurrentThread();


### PR DESCRIPTION
Replaced getMethodInfo with getInvokedMethod in instructionExecuted(.....)
->getMethodInfo returns the calling/current method not the called/invoked method:
int log(int a,int b){ //what is returned by getMethodInfo
  int x=test(a); //the method that we want
}