### PR TITLE
Travis CI implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+dist: bionic
+
+language: java
+
+jdk:
+  - openjdk8
+
+script:
+  - cd ..
+  - git clone https://github.com/javapathfinder/jpf-core.git
+  - cd jpf-core
+  - ./gradlew buildjars
+  - cd ../jpf-symbc
+  - ant clean build
+


### PR DESCRIPTION
This adds Travis CI config file that will automatically clone and build [jpf-core](https://github.com/javapathfinder/jpf-core) and then build jpf-symbc.  Jpf-core already uses Travis CI to show current build status of the project and also to build PRs.

I am aware that there are plans to migrate jpf-symbc to Java 11 and I think this will be helpful in that process.

I have already enabled Travis CI for my fork: https://travis-ci.com/github/wikumC/jpf-symbc

Once this PR is being merged, then to enable Travis CI for this repository, one of the org admins of [SymbolicPathFinder](https://github.com/SymbolicPathFinder/jpf-symbc) would need to enable this repo in their [travis-ci.com](https://travis-ci.com/) profile.