### PR TITLE
bug AASTORE on symbolic arrays?

### DIFF
--- a/src/main/gov/nasa/jpf/symbc/bytecode/symarrays/AASTORE.java
+++ b/src/main/gov/nasa/jpf/symbc/bytecode/symarrays/AASTORE.java
@@ -113,7 +113,7 @@ public class AASTORE extends gov.nasa.jpf.jvm.bytecode.AASTORE {
                         arrayRef = frame.peek(2);
                         ElementInfo eiArray = ti.getModifiableElementInfo(arrayRef);
                         eiArray.setReferenceElement(currentChoice, value);
-
+                        ((PCChoiceGenerator) cg).setCurrentPC(pc);
                         frame.pop(3); // We pop the array, the object and the index
                         return getNext(ti);
                       } else {


### PR DESCRIPTION
Hi,
I think I might have found a problem with the AASTORE for symbolic arrays.
When executed on a concrete array with a symbolic index, the path condition is not saved in the current choice generator.

(I don't have much experience with SPF, please let me know if I'm wrong :) )

Best,
Donato