### PR TITLE
throw NoSuchMethodException when INVOKESTATIC can't find callee

### DIFF
--- a/src/main/gov/nasa/jpf/symbc/bytecode/INVOKESTATIC.java
+++ b/src/main/gov/nasa/jpf/symbc/bytecode/INVOKESTATIC.java
@@ -39,7 +39,7 @@ public class INVOKESTATIC extends gov.nasa.jpf.jvm.bytecode.INVOKESTATIC {
 
 	    MethodInfo callee = getInvokedMethod(th);
 	    if (callee == null) {
-	      return th.createAndThrowException("java.lang.NoSuchMethodException!!",
+	      return th.createAndThrowException("java.lang.NoSuchMethodException",
 	                                   cname + '.' + mname);
 	    }
         BytecodeUtils.InstructionOrSuper nextInstr = BytecodeUtils.execute(this, th);


### PR DESCRIPTION
This change should get rid of this confusing error message:

> java.lang.ClassNotFoundException: class not found: java.lang.NoSuchMethodException!!

as seen [here](https://groups.google.com/g/java-pathfinder/c/Dn9JGTrXjOg/m/uiEruWtnAAAJ) and [here](https://groups.google.com/g/java-pathfinder/c/WftSE5g4rb8/m/byfeHX96AQAJ).