### PR TITLE
Improve max/min to handle NaN, -0.0f/-0.0d correctly

### DIFF
--- a/jpf-symbc/src/classes/java/lang/Math.java
+++ b/jpf-symbc/src/classes/java/lang/Math.java
@@ -38,7 +38,7 @@
 package java.lang;
 
 public class Math {
-	public static final double PI = 3.14159265358979323846;
+	public static final double PI = 3.141592653589793;
 
 	public static double abs ( double a) {
 	    return (a < 0.0) ? -a : a;
@@ -58,7 +58,7 @@ public class Math {
 
       //	 TODO:
 	  public static double max ( double a, double b) {
-		if (!(a == a))
+		if (a != a)
 			return a;
 		if (a == b)
 			return (1.0d / a > 0) ? a : b;
@@ -67,7 +67,7 @@ public class Math {
 
 	  // TODO: need to model NaN et al.
 	  public static float max ( float a, float b) {
-		if (!(a == a))
+		if (a != a)
 			return a;
 		if (a == b)
 			return (1.0f / a > 0) ? a : b;
@@ -84,7 +84,7 @@ public class Math {
 
 	  // TODO:
 	  public static double min ( double a, double b) {
-		if (!(a == a))
+		if (a != a)
 			return a;
 		if (a == b)
 			return (1.0d / a > 0) ? a : b;
@@ -93,7 +93,7 @@ public class Math {
 
 	  // TODO:
 	  public static float min ( float a, float b) {
-		 if (!(a == a))
+		 if (a != a)
 			 return a;
 		 if (a == b)
 			 return (1.0f / a > 0) ? a : b;

--- a/jpf-symbc/src/classes/java/lang/Math.java
+++ b/jpf-symbc/src/classes/java/lang/Math.java
@@ -72,7 +72,6 @@ public class Math {
 	    return (a < 0) ? -a : a;
 	  }
 
-      //	 TODO:
 	  public static double max ( double a, double b) {
 		if (a != a)
 			return a;
@@ -81,7 +80,6 @@ public class Math {
 		return (a >= b) ? a : b;
 	  }
 
-	  // TODO: need to model NaN et al.
 	  public static float max ( float a, float b) {
 		if (a != a)
 			return a;
@@ -98,7 +96,6 @@ public class Math {
 		return (a >= b) ? a : b;
 	  }
 
-	  // TODO:
 	  public static double min ( double a, double b) {
 		if (a != a)
 			return a;
@@ -106,8 +103,7 @@ public class Math {
 			return (1.0d / a < 0) ? a : b;
 		return (a <= b) ? a : b;
 	  }
-
-	  // TODO:
+	  
 	  public static float min ( float a, float b) {
 		 if (a != a)
 			 return a;

--- a/jpf-symbc/src/classes/java/lang/Math.java
+++ b/jpf-symbc/src/classes/java/lang/Math.java
@@ -38,7 +38,7 @@
 package java.lang;
 
 public class Math {
-	public static final double PI = 3.141592653589793;
+	public static final double PI = 3.14159265358979323846;
 
 	public static double abs ( double a) {
 	    return (a < 0.0) ? -a : a;
@@ -58,11 +58,19 @@ public class Math {
 
       //	 TODO:
 	  public static double max ( double a, double b) {
+		if (!(a == a))
+			return a;
+		if (a == b)
+			return (1.0d / a > 0) ? a : b;
 		return (a >= b) ? a : b;
 	  }
 
 	  // TODO: need to model NaN et al.
 	  public static float max ( float a, float b) {
+		if (!(a == a))
+			return a;
+		if (a == b)
+			return (1.0f / a > 0) ? a : b;
 		return (a >= b) ? a : b;
 	  }
 
@@ -76,11 +84,19 @@ public class Math {
 
 	  // TODO:
 	  public static double min ( double a, double b) {
-		return (a >= b) ? a : b;
+		if (!(a == a))
+			return a;
+		if (a == b)
+			return (1.0d / a > 0) ? a : b;
+		return (a <= b) ? a : b;
 	  }
 
 	  // TODO:
 	  public static float min ( float a, float b) {
+		 if (!(a == a))
+			 return a;
+		 if (a == b)
+			 return (1.0f / a > 0) ? a : b;
 		 return (a <= b) ? a : b;
 	  }
 

--- a/jpf-symbc/src/classes/java/lang/Math.java
+++ b/jpf-symbc/src/classes/java/lang/Math.java
@@ -38,6 +38,22 @@
 package java.lang;
 
 public class Math {
+
+	/**
+	 * The value of <i><b>PI</b></i> as specified (IEEE 754 standards).
+	 * <p>
+	 * The Java {@code double} type has a precision of 52 significand bits (mantissa), which is about 15–17 decimal digits.
+	 * For this particular value, it will use 15 digits to represent the mantissa.
+	 * <p>
+	 * We might see <i><b>PI</b></i> defined with ({@code 3.14159265358979323846}) in some
+	 * OpenJDK versions (e.g., JDK 8 or Adoptium builds), but
+	 * the extra digits ({@code 23846}) will get truncated and would not affect the actual stored value.
+	 * This was removed in later JDKs like JDK 19.
+	 *
+	 * @see <a href="https://github.com/openjdk/jdk8u-dev/blob/master/jdk/src/share/classes/java/lang/Math.java#L123">OpenJDK jdk8u-dev</a>
+	 * @see <a href="https://github.com/adoptium/jdk8u/blob/master/jdk/src/share/classes/java/lang/Math.java">Adoptium jdk8u</a>
+	 * @see <a href="https://github.com/openjdk/jdk19u/blob/master/src/java.base/share/classes/java/lang/Math.java#L144">OpenJDK jdk19u</a>
+	 */
 	public static final double PI = 3.141592653589793;
 
 	public static double abs ( double a) {
@@ -87,7 +103,7 @@ public class Math {
 		if (a != a)
 			return a;
 		if (a == b)
-			return (1.0d / a > 0) ? a : b;
+			return (1.0d / a < 0) ? a : b;
 		return (a <= b) ? a : b;
 	  }
 
@@ -96,7 +112,7 @@ public class Math {
 		 if (a != a)
 			 return a;
 		 if (a == b)
-			 return (1.0f / a > 0) ? a : b;
+			 return (1.0f / a < 0) ? a : b;
 		 return (a <= b) ? a : b;
 	  }
 

--- a/jpf-symbc/src/examples/TestMathMaxMin.java
+++ b/jpf-symbc/src/examples/TestMathMaxMin.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2014, United States Government, as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All rights reserved.
+ *
+ * Symbolic Pathfinder (jpf-symbc) is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This class tests the behaviour of {@code Math.max()} and {@code Math.min()} methods.
+ * <p>
+ *     Edge case handling of {@code NaN} and {@code 0.0/-0.0}
+ * </p>
+ */
+
+public class TestMathMaxMin {
+
+    /**
+     * This method tests {@code Math.max()} for {@code double} type values.
+     */
+
+    public static void testDoubleMax() {
+
+        /* This will pass as exact bit representations of 0.0 and -0.0 are not equal.
+           But earlier If we kept -0.0 as the first argument it was returning -0.0, which is wrong. */
+        assert Double.doubleToRawLongBits(Math.max(-0.0, 0.0)) == Double.doubleToRawLongBits(0.0) : "Test case Failed as Expected";
+
+        // This will fail
+        assert Double.doubleToRawLongBits(Math.max(0.0, -0.0)) == Double.doubleToRawLongBits(-0.0) : "Test case Failed";
+
+        /* This will fail as expected which is the right behaviour, earlier Math.max() returned 5.0
+           Similar to the case above. */
+        assert Double.doubleToRawLongBits(Math.max(Double.NaN, 5.0)) == Double.doubleToRawLongBits(5.0) : "Test case Failed as Expected";
+
+        // Eventually this will pass now
+        assert Double.doubleToRawLongBits(Math.max(5.0, Double.NaN)) == Double.doubleToRawLongBits(Double.NaN) : "Test case Failed";
+
+        // Additional Test Cases. Similar to the cases above.
+        System.out.println(Math.max(Double.NaN, Double.POSITIVE_INFINITY)); // earlier this returned +Infinity, but should be NaN
+        System.out.println(Math.max(Double.NaN, Double.NEGATIVE_INFINITY)); // earlier this returned -Infinity, but should be NaN
+
+    }
+
+
+    /**
+     * This method tests {@code Math.max()} for {@code float} type values.
+     */
+
+    public static void testFloatMax() {
+
+        // Tests similar to the cases above.
+        System.out.println(Math.max(0.0f, -0.0f)); // 0.0
+        System.out.println(Math.max(-0.0f, 0.0f)); // 0.0
+        System.out.println(Math.max(Float.NaN, 4.5)); // NaN
+        System.out.println(Math.max(4.5, Float.NaN)); // NaN
+    }
+
+
+    /**
+     * This method tests {@code Math.min()} for {@code double} type values.
+     */
+
+    public static void testDoubleMin() {
+
+        // Earlier this was returning 0.0, -0.0, 4.5, NaN and 9.0
+        System.out.println(Math.min(0.0, -0.0)); // 0.0
+        System.out.println(Math.min(-0.0, 0.0)); // 0.0
+        System.out.println(Math.min(Double.NaN, 4.5)); // NaN
+        System.out.println(Math.min(4.5, Double.NaN)); // NaN
+        System.out.println(Math.min(5.0, 9.0)); // 5.0
+    }
+
+
+    /**
+     * This method tests {@code Math.min()} for {@code double} type values.
+     */
+
+    public static void testFloatMin() {
+
+        // Tests similar to the cases above.
+        System.out.println(Math.min(0.0f, -0.0f)); // 0.0
+        System.out.println(Math.min(-0.0f, 0.0f)); // 0.0
+        System.out.println(Math.min(Float.NaN, 4.5)); // NaN
+        System.out.println(Math.min(4.5, Float.NaN)); // NaN
+    }
+
+    public static void main(String[] args) {
+
+        testDoubleMax(); // Math.max() for double type values.
+        testFloatMax(); // Math.max() for float type values.
+
+        testDoubleMin(); // Math.min() for double type values
+        testFloatMin(); // Math.min()  for float type values
+    }
+}
+

--- a/jpf-symbc/src/examples/TestMathMaxMin.java
+++ b/jpf-symbc/src/examples/TestMathMaxMin.java
@@ -33,10 +33,10 @@ public class TestMathMaxMin {
 
         /* This will pass as exact bit representations of 0.0 and -0.0 are not equal.
            But earlier If we kept -0.0 as the first argument it was returning -0.0, which is wrong. */
-        assert Double.doubleToRawLongBits(Math.max(-0.0, 0.0)) == Double.doubleToRawLongBits(0.0) : "Test case Failed as Expected";
+        assert Double.doubleToRawLongBits(Math.max(-0.0, 0.0)) == Double.doubleToRawLongBits(0.0) : "Test case Failed";
 
         // This will fail
-        assert Double.doubleToRawLongBits(Math.max(0.0, -0.0)) == Double.doubleToRawLongBits(-0.0) : "Test case Failed";
+        assert Double.doubleToRawLongBits(Math.max(0.0, -0.0)) == Double.doubleToRawLongBits(-0.0) : "Test case Failed as Expected";
 
         /* This will fail as expected which is the right behaviour, earlier Math.max() returned 5.0
            Similar to the case above. */
@@ -45,9 +45,9 @@ public class TestMathMaxMin {
         // Eventually this will pass now
         assert Double.doubleToRawLongBits(Math.max(5.0, Double.NaN)) == Double.doubleToRawLongBits(Double.NaN) : "Test case Failed";
 
-        // Additional Test Cases. Similar to the cases above.
-        System.out.println(Math.max(Double.NaN, Double.POSITIVE_INFINITY)); // earlier this returned +Infinity, but should be NaN
-        System.out.println(Math.max(Double.NaN, Double.NEGATIVE_INFINITY)); // earlier this returned -Infinity, but should be NaN
+        // Additional Tests, similar to the cases above.
+        assert Double.doubleToRawLongBits(Math.max(Double.NaN, Double.POSITIVE_INFINITY)) == Double.doubleToRawLongBits(Double.NaN) : "Test case Failed"; // earlier this returned +Infinity, but should be NaN
+        assert Double.doubleToRawLongBits(Math.max(Double.NaN, Double.NEGATIVE_INFINITY)) == Double.doubleToRawLongBits(Double.NaN) : "Test case Failed"; // earlier this returned -Infinity, but should be NaN
 
     }
 
@@ -59,10 +59,13 @@ public class TestMathMaxMin {
     public static void testFloatMax() {
 
         // Tests similar to the cases above.
-        System.out.println(Math.max(0.0f, -0.0f)); // 0.0
-        System.out.println(Math.max(-0.0f, 0.0f)); // 0.0
-        System.out.println(Math.max(Float.NaN, 4.5)); // NaN
-        System.out.println(Math.max(4.5, Float.NaN)); // NaN
+        assert Math.max(0.0f, -0.0f) == 0.0 : "Test case Failed"; // 0.0
+
+        assert Float.floatToRawIntBits(Math.max(-0.0f, 0.0f)) == Float.floatToRawIntBits(0.0f) : "Test case Failed"; // 0.0
+
+        assert Float.floatToRawIntBits(Math.max(Float.NaN, 4.5f)) == Float.floatToRawIntBits(Float.NaN) : "Test case Failed"; // NaN
+
+        assert Float.floatToRawIntBits(Math.max(Float.NaN, Float.POSITIVE_INFINITY)) == Float.floatToRawIntBits(Float.NaN) : "Test case Failed"; // NaN
     }
 
 
@@ -72,12 +75,18 @@ public class TestMathMaxMin {
 
     public static void testDoubleMin() {
 
-        // Earlier this was returning 0.0, -0.0, 4.5, NaN and 9.0
-        System.out.println(Math.min(0.0, -0.0)); // 0.0
-        System.out.println(Math.min(-0.0, 0.0)); // 0.0
-        System.out.println(Math.min(Double.NaN, 4.5)); // NaN
-        System.out.println(Math.min(4.5, Double.NaN)); // NaN
-        System.out.println(Math.min(5.0, 9.0)); // 5.0
+         /* Earlier this was returning 0.0, -0.0, 4.5, 9.0 and -Infinity
+            min => should be a <= b not a >= b */
+        assert Double.doubleToRawLongBits(Math.min(0.0, -0.0)) == Double.doubleToRawLongBits(-0.0) : "Test case Failed"; // -0.0
+
+        assert Double.doubleToRawLongBits(Math.min(-0.0, 0.0)) == Double.doubleToRawLongBits(-0.0) : "Test case Failed"; // -0.0
+
+        assert Double.doubleToRawLongBits(Math.min(Double.NaN, 4.5)) == Double.doubleToRawLongBits(Double.NaN) : "Test case Failed"; // NaN
+
+        assert Math.min(5.0, 9.0) == 5.0 : "Test case Failed"; // 5.0
+
+        //Additional Test case
+        assert Double.doubleToRawLongBits(Math.min(Double.NaN, Double.NEGATIVE_INFINITY)) == Double.doubleToRawLongBits(Double.NaN) : "Test case Failed"; // NaN
     }
 
 
@@ -88,10 +97,11 @@ public class TestMathMaxMin {
     public static void testFloatMin() {
 
         // Tests similar to the cases above.
-        System.out.println(Math.min(0.0f, -0.0f)); // 0.0
-        System.out.println(Math.min(-0.0f, 0.0f)); // 0.0
-        System.out.println(Math.min(Float.NaN, 4.5)); // NaN
-        System.out.println(Math.min(4.5, Float.NaN)); // NaN
+        assert Float.floatToRawIntBits(Math.min(0.0f, -0.0f)) == Float.floatToRawIntBits(-0.0f) : "Test case Failed"; // -0.0
+
+        assert Float.floatToRawIntBits(Math.min(Float.NaN, 4.5f)) == Float.floatToRawIntBits(Float.NaN) : "Test case Failed"; // NaN
+
+        assert Float.floatToRawIntBits(Math.min(Float.POSITIVE_INFINITY, Float.NEGATIVE_INFINITY)) == Float.floatToRawIntBits(Float.NEGATIVE_INFINITY) : "Test case Failed"; // -Infinity
     }
 
     public static void main(String[] args) {

--- a/jpf-symbc/src/examples/TestMathMaxMin.jpf
+++ b/jpf-symbc/src/examples/TestMathMaxMin.jpf
@@ -1,0 +1,8 @@
+target=TestMathMaxMin
+classpath=${jpf-symbc}/build/examples
+sourcepath=${jpf-symbc}/src/examples
+
+#symbolic.method=TestMathMaxMin.testMax(con#con)
+#listener=gov.nasa.jpf.symbc.concolic.ConcreteExecutionListener
+#listener=gov.nasa.jpf.symbc.SymbolicListener
+#search.multiple_errors=true


### PR DESCRIPTION
In this PR, I made some changes to the `jpf-symbc/src/classes/java/lang/Math.java`:

**Handles**

- For double and float Math.min() and Math.max()
- NaN (Not a Number) [Double.NaN/Float.NaN]
- 0.0f and -0.0f / 0.0d and -0.0d

 ```java
     if(a != a) // NaN is not equal to itself
        return a;
  ```
  
  ```java
      return (1.0f / a > 0) ? a : b; 
  ```
We can also use raw conversion of bits as Nan cannot map to -0.0.
@yannicnoller @corinus @sohah 