### PR TITLE
feat: Add support for StringBuilder.append(char[]) with symbolic hand…

### DIFF
--- a/jpf-symbc/src/examples/SBCharArrayAppendTest.java
+++ b/jpf-symbc/src/examples/SBCharArrayAppendTest.java
@@ -1,0 +1,16 @@
+import gov.nasa.jpf.symbc.Debug;
+
+public class SBCharArrayAppendTest {
+
+    public static void main(String[] args) {
+        StringBuilder sb = new StringBuilder();
+        String s = Debug.makeSymbolicString("s");
+        char[] array = new char[3];
+        array[0] = 'J';
+        array[1] = 'P';
+        array[2] = 'F';
+        sb.append(s);
+        sb.append(array);
+        assert sb.toString().equals("JPF");
+    }
+}

--- a/jpf-symbc/src/examples/SBCharArrayAppendTest.java
+++ b/jpf-symbc/src/examples/SBCharArrayAppendTest.java
@@ -1,0 +1,64 @@
+import gov.nasa.jpf.symbc.Debug;
+
+public class SBCharArrayAppendTest {
+
+    public static void main(String[] args) {
+        if(test1()) {
+            System.out.println("Test 1 passed");
+        } else {
+            System.out.println("Test 1 failed");
+        }
+
+        if(test2()) {
+            System.out.println("Test 2 passed");
+        } else {
+            System.out.println("Test 2 failed");
+        }
+
+        if(test3()) {
+            System.out.println("Test 3 passed");
+        } else {
+            System.out.println("Test 3 failed");
+        }
+    }
+
+    //    Test case for symbolic StringBuilder and a concrete char array
+    public static boolean test1() {
+        StringBuilder sb = new StringBuilder();
+        String s = Debug.makeSymbolicString("s");
+        char[] array = new char[3];
+        array[0] = 'J';
+        array[1] = 'P';
+        array[2] = 'F';
+        sb.append(s);
+        sb.append(array);
+        return sb.toString().equals("JPF");
+    }
+
+    //    Test case for concrete StringBuilder and  symbolic char array
+    public static boolean test2() {
+        StringBuilder sb = new StringBuilder();
+        String s = "JPF";
+        char[] array = new char[3];
+        array[0] = Debug.makeSymbolicChar("c1");
+        array[1] = Debug.makeSymbolicChar("c2");
+        array[2] = Debug.makeSymbolicChar("c3");
+        sb.append(s);
+        sb.append(array);
+        return sb.toString().equals("JPF" + "abc");
+    }
+
+    //    Test case for symbolic StringBuilder and symbolic char array
+    public static boolean test3() {
+        StringBuilder sb = new StringBuilder();
+        String s = Debug.makeSymbolicString("s1");
+        char[] array = new char[3];
+        array[0] = Debug.makeSymbolicChar("c1");
+        array[1] = Debug.makeSymbolicChar("c2");
+        array[2] = Debug.makeSymbolicChar("c3");
+        sb.append(s);
+        sb.append(array);
+        return sb.toString().equals("JPF" + "abc");
+    }
+
+}

--- a/jpf-symbc/src/examples/SBCharArrayAppendTest.jpf
+++ b/jpf-symbc/src/examples/SBCharArrayAppendTest.jpf
@@ -1,0 +1,19 @@
+target=SBCharArrayAppendTest
+
+classpath=${jpf-symbc}/build/examples
+
+symbolic.dp=z3bitvector
+symbolic.min_int=-2147483648
+symbolic.max_int=2147483647
+symbolic.min_double=-10000.0
+symbolic.max_double=10000.0
+symbolic.bvlength=64
+search.depth_limit=13
+symbolic.strings=true
+symbolic.string_dp=z3str3
+symbolic.lazy=on
+symbolic.jrarrays=true
+listener = .symbc.SymbolicListener
+
+symbolic.optimizechoices=true
+symbolic.debug=true

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/bytecode/SymbolicStringHandler.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/bytecode/SymbolicStringHandler.java
@@ -2216,6 +2216,10 @@ public class SymbolicStringHandler {
 			} else { //stringbuilder
 				handled = handleStringBuilderAppend3(invInst, th);
 			}
+		} else if(argTypes[0].equals("char[]") && argTypes.length == 3) {
+			//TODO need to handleCharArrayAppend3()
+		} else if(argTypes[0].equals("char[]")) {
+			handleCharArrayAppend(invInst, th);
 		} else if (argTypes[0].equals("java.lang.String")) {
 			handleStringAppend(invInst, th);
 		} else if ((argTypes[0].equals("java.lang.StringBuilder")) || (argTypes[0].equals("java.lang.StringBuffer"))) {
@@ -2685,6 +2689,45 @@ public class SymbolicStringHandler {
 		}
 	}
 
+	public void handleCharArrayAppend(JVMInvokeInstruction invInst, ThreadInfo th) {
+		StackFrame sf = th.getModifiableTopFrame();
+		Object sym_v1 = sf.getOperandAttr(0);
+		SymbolicStringBuilder sym_v2 = (SymbolicStringBuilder) sf.getOperandAttr(1);
+
+		if (sym_v2 == null) {
+			sym_v2 = new SymbolicStringBuilder();
+		}
+		if ((sym_v1 == null) && (sym_v2.getstr() == null)) {
+			throw new RuntimeException("ERROR: symbolic string method must have one symbolic operand");
+		} else {
+			int s1 = sf.pop();
+			int s2 = sf.pop();
+
+			if(sym_v1 == null) {
+				ElementInfo charArrayEI = th.getElementInfo(s1);
+				char[] charArray = charArrayEI.asCharArray();
+				String val = new String(charArray);
+				sym_v2._append(val);
+				sf.push(s2, true);
+			} else if(sym_v2.getstr() == null) {
+				ElementInfo e1 = th.getElementInfo(s2);
+				String val = getStringEquiv(e1);
+				sym_v2.putstr(new StringConstant(val));
+				StringExpression charArrayExpr = (StringExpression) sym_v1;
+				sym_v2._append(charArrayExpr);
+
+				sf.push(s2, true);
+			} else {
+				StringExpression charArrayExpr = (StringExpression) sym_v1;
+				sym_v2._append(charArrayExpr);
+
+				sf.push(s2, true);
+			}
+		}
+
+		sf.setOperandAttr(sym_v2);
+	}
+
 	/*
 	 * String s1 = AbstractionUtilityMethods.unknownString(); String s2 =
 	 * AbstractionUtilityMethods.unknownString(); String s4 =
@@ -2778,6 +2821,8 @@ public class SymbolicStringHandler {
 			sf.setOperandAttr(sym_v2);
 		}
 	}
+
+
 
 	public String getStringEquiv(ElementInfo ei) {
 		String objectType = ei.getType();


### PR DESCRIPTION
While investigating `jbmc-regression/StringBuilderAppend02.ym`l, I noticed there was no support for 

`StringBuilder.append(char[])`,
`StringBuilder.append(char[], start, end)` and 
`StringBuilder.append(StringBuilder, start, end)`. 

This PR adds initial support for `StringBuilder.append(char[])`.

I wanted to make a small contribution first but I am willing to add support for the other methods as well. Can you please review this and suggest any changes or refinements that need to be done.

Thank you!