### PR TITLE
GSOC: Support portfolio of solvers

### DIFF
--- a/jpf-symbc/src/examples/UnsatExample.java
+++ b/jpf-symbc/src/examples/UnsatExample.java
@@ -1,0 +1,12 @@
+public class UnsatExample {
+
+    public static void test(int x) {
+        if (x > 5 && x < 3) {
+            System.out.println("UNSAT Path");
+        }
+    }
+
+    public static void main(String[] args) {
+        test(0);
+    }
+}

--- a/jpf-symbc/src/examples/UnsatExample.jpf
+++ b/jpf-symbc/src/examples/UnsatExample.jpf
@@ -1,0 +1,7 @@
+target=UnsatExample
+classpath=${jpf-symbc}/build/examples
+sourcepath=${jpf-symbc}/src/examples
+symbolic.method = UnsatExample.test(sym)
+
+symbolic.dp=z3,choco
+symbolic.debug=true

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/SymbolicInstructionFactory.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/SymbolicInstructionFactory.java
@@ -29,6 +29,10 @@ import gov.nasa.jpf.util.ClassInfoFilter;
 import gov.nasa.jpf.vm.ClassInfo;
 import gov.nasa.jpf.vm.Instruction;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
 
 public class SymbolicInstructionFactory extends gov.nasa.jpf.jvm.bytecode.InstructionFactory {
 
@@ -539,6 +543,7 @@ public class SymbolicInstructionFactory extends gov.nasa.jpf.jvm.bytecode.Instru
 	      }
 
 	static public String[] dp;
+	static public Set<String> dpSet;
 
 	/* Symbolic String configuration */
 	static public String[] string_dp;
@@ -665,7 +670,19 @@ public class SymbolicInstructionFactory extends gov.nasa.jpf.jvm.bytecode.Instru
 				dp = new String[1];
 				dp[0] = "choco";
 			}
-			if (debugMode) System.out.println("symbolic.dp="+dp[0]);
+			dpSet = new HashSet<>();
+			for(String s : dp) {
+				if(dpSet.contains(s.toLowerCase())) {
+					throw new IllegalArgumentException("Duplicate solver in symbolic.dp: " + s);
+				}
+				dpSet.add(s.toLowerCase());
+			}
+
+			if(dpSet.contains("no_solver") && dpSet.size() > 1) {
+				throw new IllegalArgumentException("The 'no_solver' option cannot be used together with other solvers.");
+			}
+
+			if (debugMode) System.out.println("symbolic.dp="+ Arrays.toString(dp));
 
 			stringTimeout = conf.getInt("symbolic.string_dp_timeout_ms");
 			if (debugMode) System.out.println("symbolic.string_dp_timeout_ms="+stringTimeout);
@@ -754,12 +771,12 @@ public class SymbolicInstructionFactory extends gov.nasa.jpf.jvm.bytecode.Instru
 				heuristicPartitionMode = false;
 			}
 
-			if(dp[0].equalsIgnoreCase("choco") || dp[0].equalsIgnoreCase("debug") || dp[0].equalsIgnoreCase("compare") || dp == null) { // default is choco
+			if(dpSet.contains("choco") || dpSet.contains("debug") || dpSet.contains("compare")) {
 			  ProblemChoco.timeBound = conf.getInt("symbolic.choco_time_bound", 30000);
 			  if (debugMode) System.out.println("symbolic.choco_time_bound="+ProblemChoco.timeBound);
 			}
 			//load CORAL's parameters
-			if (dp[0].equalsIgnoreCase("coral") || dp[0].equalsIgnoreCase("debug") || dp[0].equalsIgnoreCase("compare")) {
+			if (dpSet.contains("coral") || dpSet.contains("debug") || dpSet.contains("compare")) {
 				ProblemCoral.configure(conf);
 			}
 

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/SymbolicInstructionFactory.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/SymbolicInstructionFactory.java
@@ -682,6 +682,10 @@ public class SymbolicInstructionFactory extends gov.nasa.jpf.jvm.bytecode.Instru
 				throw new IllegalArgumentException("The 'no_solver' option cannot be used together with other solvers.");
 			}
 
+			if(dpSet.contains("compare") && dpSet.size() > 1) {
+				throw new IllegalArgumentException("The 'compare' option cannot be used together with other solvers.");
+			}
+
 			if (debugMode) System.out.println("symbolic.dp="+ Arrays.toString(dp));
 
 			stringTimeout = conf.getInt("symbolic.string_dp_timeout_ms");

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/SymbolicListener.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/SymbolicListener.java
@@ -673,8 +673,8 @@ public class SymbolicListener extends PropertyListenerAdapter implements Publish
     // -------- the publisher interface
     @Override
     public void publishFinished(Publisher publisher) {
-        String[] dp = SymbolicInstructionFactory.dp;
-        if (dp[0].equalsIgnoreCase("no_solver") || dp[0].equalsIgnoreCase("cvc3bitvec"))
+        Set<String> dpSet = SymbolicInstructionFactory.dpSet;
+        if (dpSet.contains("no_solver") || dpSet.contains("cvc3bitvec"))
             return;
 
         PrintWriter pw = publisher.getOut();

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/bytecode/IFEQ.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/bytecode/IFEQ.java
@@ -27,6 +27,9 @@ import gov.nasa.jpf.vm.Instruction;
 import gov.nasa.jpf.vm.StackFrame;
 import gov.nasa.jpf.vm.ThreadInfo;
 
+import java.util.Set;
+
+
 // we should factor out some of the code and put it in a parent class for all "if statements"
 
 /**
@@ -46,14 +49,14 @@ public class IFEQ extends gov.nasa.jpf.jvm.bytecode.IFEQ {
             return super.execute(ti);
         } else { // the condition is symbolic
 
-            String[] dp = SymbolicInstructionFactory.dp;
+            Set<String> dpSet = SymbolicInstructionFactory.dpSet;
             ChoiceGenerator<?> cg;
 
             if (!ti.isFirstStepInsn()) { // first time around
                 if (SymbolicInstructionFactory.collect_constraints)
                     cg = new PCChoiceGenerator(1);
                 else {
-                    if (dp[0].equalsIgnoreCase("omega")) // hack because omega does not handle not or or correctly
+                    if (dpSet.contains("omega")) // hack because omega does not handle not or or correctly
                         cg = new PCChoiceGenerator(3);
                     else
                         cg = new PCChoiceGenerator(2);
@@ -111,7 +114,7 @@ public class IFEQ extends gov.nasa.jpf.jvm.bytecode.IFEQ {
                 }
                 return getTarget();
             } else {
-                if (dp[0].equalsIgnoreCase("omega")) {// hack
+                if (dpSet.contains("omega")) {// hack
                     if ((Integer) cg.getNextChoice() == 0)
                         pc._addDet(Comparator.GT, sym_v, 0);
                     else {// ==2

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/bytecode/IFNE.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/bytecode/IFNE.java
@@ -27,6 +27,10 @@ import gov.nasa.jpf.vm.Instruction;
 import gov.nasa.jpf.vm.StackFrame;
 import gov.nasa.jpf.vm.ThreadInfo;
 
+import java.util.Set;
+
+import static gov.nasa.jpf.symbc.SymbolicInstructionFactory.dpSet;
+
 // we should factor out some of the code and put it in a parent class for all "if statements"
 
 /**
@@ -47,14 +51,14 @@ public class IFNE extends gov.nasa.jpf.jvm.bytecode.IFNE {
             return super.execute(ti);
         } else { // the condition is symbolic
 
-            String[] dp = SymbolicInstructionFactory.dp;
+            Set<String> dp = dpSet;
 
             ChoiceGenerator<?> cg;
 
             if (!ti.isFirstStepInsn()) { // first time around
                 if (SymbolicInstructionFactory.collect_constraints)
                     cg = new PCChoiceGenerator(1);
-                else if (dp[0].equalsIgnoreCase("omega")) // hack because omega does not handle not or or correctly
+                else if (dpSet.contains("omega")) // hack because omega does not handle not or or correctly
                     cg = new PCChoiceGenerator(3);
                 else
                     cg = new PCChoiceGenerator(2);
@@ -93,7 +97,7 @@ public class IFNE extends gov.nasa.jpf.jvm.bytecode.IFNE {
             assert pc != null;
 
             if (conditionValue) {
-                if (dp[0].equalsIgnoreCase("omega")) {// hack
+                if (dpSet.contains("omega")) {// hack
                     if ((Integer) cg.getNextChoice() == 1)
                         pc._addDet(Comparator.GT, sym_v, 0);
                     else {// 2

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/numeric/MinMax.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/numeric/MinMax.java
@@ -112,7 +112,9 @@ public class MinMax {
 	/**
 	 * Lower bound on symbolic real variables.
 	 */
-	private static double minDouble = Double.MIN_VALUE; //-8;
+	// Double.MIN_VALUE represents the smallest positive value, not the most negative one
+	private static double minDouble = -Double.MAX_VALUE; //-8;
+
 
 	/**
 	 * Upper bound on symbolic real variables.

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/numeric/SymbolicConstraintsGeneral.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/numeric/SymbolicConstraintsGeneral.java
@@ -135,22 +135,36 @@ public class SymbolicConstraintsGeneral {
                 System.out.println("Using solver: " + pb.getClass().getSimpleName());
             }
 
-            ProblemGeneral tempPb = PCParser.parse(pc, pb);
+            try {
+                ProblemGeneral tempPb = PCParser.parse(pc, pb);
 
-            if (tempPb == null)
-                continue;
-            else {
-                pb = tempPb;
+                if (tempPb == null)
+                    continue;
+                else {
+                    pb = tempPb;
 
-                // YN: z3 optimize
-                if (Observations.lastObservedSymbolicExpression != null) {
-                    if (pb instanceof ProblemZ3Optimize) {
-                        ((ProblemZ3Optimize) pb).maximize(
-                                PCParser.getExpression((IntegerExpression) Observations.lastObservedSymbolicExpression));
+                    // YN: z3 optimize
+                    if (Observations.lastObservedSymbolicExpression != null) {
+                        if (pb instanceof ProblemZ3Optimize) {
+                            ((ProblemZ3Optimize) pb).maximize(
+                                    PCParser.getExpression((IntegerExpression) Observations.lastObservedSymbolicExpression));
+                        }
                     }
-                }
 
-                result = pb.solve();
+                    result = pb.solve();
+                }
+            } catch (Exception e) {
+                // throw an exception if no solver is able to produce a result
+                if(i == solvers.size()-1 && result == null) {
+                    throw new RuntimeException(
+                            "Error: no solver could parse or solve the path condition: " + pc + "\n");
+                } else {
+                    if(SymbolicInstructionFactory.debugMode) {
+                        System.err.println("Exception in parsing or solving with solver " + pb.getClass().getSimpleName() + ": " + e.getMessage());
+                        e.printStackTrace();
+                    }
+                    continue;
+                }
             }
 
             if (SymbolicInstructionFactory.debugMode)
@@ -196,6 +210,9 @@ public class SymbolicConstraintsGeneral {
     }
 
     public void cleanup() {
+        if(solvers == null) {
+            return;
+        }
         for(int i = 0; i < solvers.size(); i++) {
             ProblemGeneral solver = solvers.get(i);
             if (solver instanceof ProblemCVC3) {

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/numeric/SymbolicConstraintsGeneral.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/numeric/SymbolicConstraintsGeneral.java
@@ -54,9 +54,9 @@ import java.util.Map.Entry;
 // types come in and out of each particular dp !!!!!!!!!!!!!!!
 
 public class SymbolicConstraintsGeneral {
-    List<ProblemGeneral> solvers;
+    protected List<ProblemGeneral> solvers;
     protected ProblemGeneral resultSolver;
-    protected Boolean result; // tells whether result is satisfiable or not
+    protected Boolean result;
 
     public boolean isSatisfiable(PathCondition pc) {
         if (pc == null || pc.count == 0) {
@@ -70,6 +70,7 @@ public class SymbolicConstraintsGeneral {
                     + SymbolicInstructionFactory.maxPcLength + ".  Pretending it is unsatisfiable.");
             return false;
         }
+
         if (SymbolicInstructionFactory.maxPcMSec > 0 && System.currentTimeMillis()
                 - SymbolicInstructionFactory.startSystemMillis > SymbolicInstructionFactory.maxPcMSec) {
             System.out.println("## Warning: Exploration time exceeds symbolic.max_pc_msec="
@@ -122,7 +123,7 @@ public class SymbolicConstraintsGeneral {
                         "## Error: unknown decision procedure symbolic.dp contains " + s + "\n(use choco or IAsolver or CVC3)");
         }
 
-        for(int i = 0; i < solvers.size(); i++) {
+        for (int i = 0; i < solvers.size(); i++) {
             resultSolver = solvers.get(i);
 
             if (SymbolicInstructionFactory.debugMode) {
@@ -131,48 +132,46 @@ public class SymbolicConstraintsGeneral {
 
             try {
                 ProblemGeneral tempPb = PCParser.parse(pc, resultSolver);
+
                 if (tempPb == null) {
                     result = Boolean.FALSE;
-                }
-                else {
-                    resultSolver = tempPb;
+                } else {
                     // YN: z3 optimize
                     if (Observations.lastObservedSymbolicExpression != null) {
                         if (resultSolver instanceof ProblemZ3Optimize) {
                             ((ProblemZ3Optimize) resultSolver).maximize(
-                                    PCParser.getExpression((IntegerExpression) Observations.lastObservedSymbolicExpression));
+                                    PCParser.getExpression(
+                                            (IntegerExpression) Observations.lastObservedSymbolicExpression));
                         }
                     }
                     result = resultSolver.solve();
                 }
+
+                break;
+
             } catch (Exception e) {
+                if (SymbolicInstructionFactory.debugMode) {
+                    System.err.println("Exception in parsing or solving with solver "
+                            + resultSolver.getClass().getSimpleName() + ": " + e.getMessage());
+                    e.printStackTrace();
+                }
                 // throw an exception if no solver is able to produce a result
-                if(i == solvers.size()-1) {
+                if (i == solvers.size() - 1) {
                     throw new RuntimeException(
                             "Error: no solver could parse or solve the path condition: " + pc + "\n");
-                } else {
-                    if(SymbolicInstructionFactory.debugMode) {
-                        System.err.println("Exception in parsing or solving with solver " + resultSolver.getClass().getSimpleName() + ": " + e.getMessage());
-                        e.printStackTrace();
-                    }
-                    continue;
                 }
             }
+        }
 
-            if (SymbolicInstructionFactory.debugMode)
-                System.out.println("numeric PC: " + pc + " -> " + result + "\n");
 
-            if (SymbolicInstructionFactory.regressMode) {
-                String output = "##NUMERIC PC: ";
-                output = output + (result == Boolean.TRUE ? "(SOLVED)" : "(UNSOLVED)");
-                output = output + " " + pc;
-                System.out.println(output);
-            }
+        if (SymbolicInstructionFactory.debugMode)
+            System.out.println("numeric PC: " + pc + " -> " + result + "\n");
 
-            if (result == null) {
-                result = Boolean.FALSE;
-            }
-            break;
+        if (SymbolicInstructionFactory.regressMode) {
+            String output = "##NUMERIC PC: ";
+            output = output + (result == Boolean.TRUE ? "(SOLVED)" : "(UNSOLVED)");
+            output = output + " " + pc;
+            System.out.println(output);
         }
 
         return result == Boolean.TRUE ? true : false;
@@ -201,24 +200,22 @@ public class SymbolicConstraintsGeneral {
     }
 
     public void cleanup() {
-        if(solvers == null) {
-            return;
-        }
-        for(int i = 0; i < solvers.size(); i++) {
-            ProblemGeneral solver = solvers.get(i);
-            if (solver instanceof ProblemCVC3) {
-                ((ProblemCVC3) solver).cleanup();
-            } else if (solver instanceof ProblemCoral) {
-                ((ProblemCoral) solver).cleanup();
-            } else if (solver instanceof ProblemZ3) {
-                ((ProblemZ3) solver).cleanup();
-            } else if (solver instanceof ProblemZ3BitVector) {
-                ((ProblemZ3BitVector) solver).cleanup();
-            } else if (solver instanceof ProblemZ3Optimize) {
-                ((ProblemZ3Optimize) solver).cleanup();
+        if (solvers != null) {
+            for (int i = 0; i < solvers.size(); i++) {
+                ProblemGeneral solver = solvers.get(i);
+                if (solver instanceof ProblemCVC3) {
+                    ((ProblemCVC3) solver).cleanup();
+                } else if (solver instanceof ProblemCoral) {
+                    ((ProblemCoral) solver).cleanup();
+                } else if (solver instanceof ProblemZ3) {
+                    ((ProblemZ3) solver).cleanup();
+                } else if (solver instanceof ProblemZ3BitVector) {
+                    ((ProblemZ3BitVector) solver).cleanup();
+                } else if (solver instanceof ProblemZ3Optimize) {
+                    ((ProblemZ3Optimize) solver).cleanup();
+                }
             }
         }
-
     }
 
     public boolean solve(PathCondition pc) {
@@ -360,7 +357,7 @@ public class SymbolicConstraintsGeneral {
                     SymbolicReal pcVar = e.getKey();
                     Object dpVar = e.getValue();
                     double e_value = resultSolver.getRealValue(dpVar); // may be undefined: throws an exception
-                    pcVar.solution = e_value; 
+                    pcVar.solution = e_value;
                     result.put(pcVar.getName(), e_value);
                 }
             } catch (Exception exp) {

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/numeric/SymbolicConstraintsGeneral.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/numeric/SymbolicConstraintsGeneral.java
@@ -55,7 +55,7 @@ import java.util.Map.Entry;
 
 public class SymbolicConstraintsGeneral {
     List<ProblemGeneral> solvers;
-    protected ProblemGeneral pb;
+    protected ProblemGeneral resultSolver;
     protected Boolean result; // tells whether result is satisfiable or not
 
     public boolean isSatisfiable(PathCondition pc) {
@@ -81,86 +81,78 @@ public class SymbolicConstraintsGeneral {
         // System.out.println("checking: PC "+pc);
         solvers = new ArrayList<>();
         String[] dp = SymbolicInstructionFactory.dp;
-        if (dp == null) { // default: use choco
-            pb = new ProblemChoco();
-        } else {
-            for(String s : dp) {
-                if (s.equalsIgnoreCase("choco")) {
-                    solvers.add(new ProblemChoco());
-                    // } else if(dp[0].equalsIgnoreCase("choco2")){
-                    // pb = new ProblemChoco2();
-                } else if (s.equalsIgnoreCase("coral")) {
-                    solvers.add(new ProblemCoral());
-                } else if (s.equalsIgnoreCase("iasolver")) {
-                    solvers.add(new ProblemIAsolver());
-                } else if (s.equalsIgnoreCase("cvc3")) {
-                    solvers.add(new ProblemCVC3());
-                } else if (s.equalsIgnoreCase("cvc3bitvec")) {
-                    solvers.add(new ProblemCVC3BitVector());
-                } else if (s.equalsIgnoreCase("yices")) {
-                    solvers.add(new ProblemYices());
-                } else if (s.equalsIgnoreCase("z3")) {
-                    solvers.add(new ProblemZ3());
-                } else if (s.equalsIgnoreCase("z3inc")) {
-                    solvers.add(new ProblemZ3Incremental());
-                } else if (s.equalsIgnoreCase("z3bitvectorinc")) {
-                    solvers.add(new ProblemZ3BitVectorIncremental());
-                } else if (s.equalsIgnoreCase("debug")) {
-                    solvers.add(new DebugSolvers(pc));
-                } else if (s.equalsIgnoreCase("compare")) {
-                    solvers.add(new ProblemCompare(pc, this));
-                } else if (s.equalsIgnoreCase("z3bitvector")) {
-                    solvers.add(new ProblemZ3BitVector());
-                } else if (s.equalsIgnoreCase("z3optimize")) {
-                    solvers.add(new ProblemZ3Optimize());
-                }
-                // added option to have no-solving
-                // as a result symbolic execution will explore an over-approximation of the
-                // program paths
-                // equivalent to a CFG analysis
-                else if (s.equalsIgnoreCase("no_solver")) {
-                    return true;
-                } else
-                    throw new RuntimeException(
-                            "## Error: unknown decision procedure symbolic.dp=" + dp[0] + "\n(use choco or IAsolver or CVC3)");
+        for (String s : dp) {
+            if (s.equalsIgnoreCase("choco")) {
+                solvers.add(new ProblemChoco());
+                // } else if(dp[0].equalsIgnoreCase("choco2")){
+                // pb = new ProblemChoco2();
+            } else if (s.equalsIgnoreCase("coral")) {
+                solvers.add(new ProblemCoral());
+            } else if (s.equalsIgnoreCase("iasolver")) {
+                solvers.add(new ProblemIAsolver());
+            } else if (s.equalsIgnoreCase("cvc3")) {
+                solvers.add(new ProblemCVC3());
+            } else if (s.equalsIgnoreCase("cvc3bitvec")) {
+                solvers.add(new ProblemCVC3BitVector());
+            } else if (s.equalsIgnoreCase("yices")) {
+                solvers.add(new ProblemYices());
+            } else if (s.equalsIgnoreCase("z3")) {
+                solvers.add(new ProblemZ3());
+            } else if (s.equalsIgnoreCase("z3inc")) {
+                solvers.add(new ProblemZ3Incremental());
+            } else if (s.equalsIgnoreCase("z3bitvectorinc")) {
+                solvers.add(new ProblemZ3BitVectorIncremental());
+            } else if (s.equalsIgnoreCase("debug")) {
+                solvers.add(new DebugSolvers(pc));
+            } else if (s.equalsIgnoreCase("compare")) {
+                solvers.add(new ProblemCompare(pc, this));
+            } else if (s.equalsIgnoreCase("z3bitvector")) {
+                solvers.add(new ProblemZ3BitVector());
+            } else if (s.equalsIgnoreCase("z3optimize")) {
+                solvers.add(new ProblemZ3Optimize());
             }
+            // added option to have no-solving
+            // as a result symbolic execution will explore an over-approximation of the
+            // program paths
+            // equivalent to a CFG analysis
+            else if (s.equalsIgnoreCase("no_solver")) {
+                return true;
+            } else
+                throw new RuntimeException(
+                        "## Error: unknown decision procedure symbolic.dp contains " + s + "\n(use choco or IAsolver or CVC3)");
         }
 
-
-
         for(int i = 0; i < solvers.size(); i++) {
-            pb = solvers.get(i);
+            resultSolver = solvers.get(i);
 
             if (SymbolicInstructionFactory.debugMode) {
-                System.out.println("Using solver: " + pb.getClass().getSimpleName());
+                System.out.println("Using solver: " + resultSolver.getClass().getSimpleName());
             }
 
             try {
-                ProblemGeneral tempPb = PCParser.parse(pc, pb);
-
-                if (tempPb == null)
-                    continue;
+                ProblemGeneral tempPb = PCParser.parse(pc, resultSolver);
+                if (tempPb == null) {
+                    result = Boolean.FALSE;
+                }
                 else {
-                    pb = tempPb;
-
+                    resultSolver = tempPb;
                     // YN: z3 optimize
                     if (Observations.lastObservedSymbolicExpression != null) {
-                        if (pb instanceof ProblemZ3Optimize) {
-                            ((ProblemZ3Optimize) pb).maximize(
+                        if (resultSolver instanceof ProblemZ3Optimize) {
+                            ((ProblemZ3Optimize) resultSolver).maximize(
                                     PCParser.getExpression((IntegerExpression) Observations.lastObservedSymbolicExpression));
                         }
                     }
-
-                    result = pb.solve();
+                    result = resultSolver.solve();
                 }
             } catch (Exception e) {
                 // throw an exception if no solver is able to produce a result
-                if(i == solvers.size()-1 && result == null) {
+                if(i == solvers.size()-1) {
                     throw new RuntimeException(
                             "Error: no solver could parse or solve the path condition: " + pc + "\n");
                 } else {
                     if(SymbolicInstructionFactory.debugMode) {
-                        System.err.println("Exception in parsing or solving with solver " + pb.getClass().getSimpleName() + ": " + e.getMessage());
+                        System.err.println("Exception in parsing or solving with solver " + resultSolver.getClass().getSimpleName() + ": " + e.getMessage());
                         e.printStackTrace();
                     }
                     continue;
@@ -178,13 +170,12 @@ public class SymbolicConstraintsGeneral {
             }
 
             if (result == null) {
-                continue;
+                result = Boolean.FALSE;
             }
-            if (result == Boolean.TRUE) {
-                return true;
-            }
+            break;
         }
-        return false;
+
+        return result == Boolean.TRUE ? true : false;
     }
 
     public boolean isSatisfiableGreen(PathCondition pc) {
@@ -262,10 +253,10 @@ public class SymbolicConstraintsGeneral {
                     Entry<SymbolicReal, Object> e = i_real.next();
                     SymbolicReal pcVar = e.getKey();
                     Object dpVar = e.getValue();
-                    pcVar.solution = pb.getRealValue(dpVar); // may be undefined: throws an exception
+                    pcVar.solution = resultSolver.getRealValue(dpVar); // may be undefined: throws an exception
                 }
             } catch (Exception exp) {
-                this.catchBody(PCParser.symRealVar, pb, pc);
+                this.catchBody(PCParser.symRealVar, resultSolver, pc);
             } // end catch
 
             // compute solutions for integer variables
@@ -274,7 +265,7 @@ public class SymbolicConstraintsGeneral {
             // try {
             while (i_int.hasNext()) {
                 Entry<SymbolicInteger, Object> e = i_int.next();
-                e.getKey().solution = pb.getIntValue(e.getValue());
+                e.getKey().solution = resultSolver.getIntValue(e.getValue());
 
             }
             // }
@@ -292,10 +283,11 @@ public class SymbolicConstraintsGeneral {
              */
             cleanup();
             return true;
-        } else
+        } else {
             return false;
-    }
+        }
 
+    }
     /**
      * The "ProblemCompare" solver calls this to deal with yices and choco refinements of solution ranges.
      */
@@ -367,12 +359,12 @@ public class SymbolicConstraintsGeneral {
                     Entry<SymbolicReal, Object> e = i_real.next();
                     SymbolicReal pcVar = e.getKey();
                     Object dpVar = e.getValue();
-                    double e_value = pb.getRealValue(dpVar); // may be undefined: throws an exception
+                    double e_value = resultSolver.getRealValue(dpVar); // may be undefined: throws an exception
                     pcVar.solution = e_value; 
                     result.put(pcVar.getName(), e_value);
                 }
             } catch (Exception exp) {
-                this.catchBody(PCParser.symRealVar, pb, pc);
+                this.catchBody(PCParser.symRealVar, resultSolver, pc);
             }
 
             // compute solutions for integer variables
@@ -381,7 +373,7 @@ public class SymbolicConstraintsGeneral {
             // try {
             while (i_int.hasNext()) {
                 Entry<SymbolicInteger, Object> e = i_int.next();
-                long e_value = pb.getIntValue(e.getValue());
+                long e_value = resultSolver.getIntValue(e.getValue());
                 e.getKey().solution = e_value;
                 result.put(e.getKey().getName(), e_value);
 

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/numeric/SymbolicConstraintsGeneral.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/numeric/SymbolicConstraintsGeneral.java
@@ -58,7 +58,7 @@ public class SymbolicConstraintsGeneral {
     protected ProblemGeneral resultSolver;
     protected Boolean result;
 
-    public boolean isSatisfiable(PathCondition pc) {
+    public boolean isSatisfiable(PathCondition pc){
         if (pc == null || pc.count == 0) {
             if (SymbolicInstructionFactory.debugMode)
                 System.out.println("## Warning: empty path condition");
@@ -157,7 +157,7 @@ public class SymbolicConstraintsGeneral {
                 }
                 // throw an exception if no solver is able to produce a result
                 if (i == solvers.size() - 1) {
-                    throw new RuntimeException(
+                    throw new NoSolverSucceededException(
                             "Error: no solver could parse or solve the path condition: " + pc + "\n");
                 }
             }

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/numeric/SymbolicConstraintsGeneral.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/numeric/SymbolicConstraintsGeneral.java
@@ -45,6 +45,8 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
+import java.util.List;
+import java.util.ArrayList;
 import java.util.Map.Entry;
 
 // generalized to use different constraint solvers/decision procedures
@@ -52,6 +54,7 @@ import java.util.Map.Entry;
 // types come in and out of each particular dp !!!!!!!!!!!!!!!
 
 public class SymbolicConstraintsGeneral {
+    List<ProblemGeneral> solvers;
     protected ProblemGeneral pb;
     protected Boolean result; // tells whether result is satisfiable or not
 
@@ -76,92 +79,98 @@ public class SymbolicConstraintsGeneral {
 
         // if (SymbolicInstructionFactory.debugMode)
         // System.out.println("checking: PC "+pc);
-
+        solvers = new ArrayList<>();
         String[] dp = SymbolicInstructionFactory.dp;
         if (dp == null) { // default: use choco
             pb = new ProblemChoco();
-        } else if (dp[0].equalsIgnoreCase("choco")) {
-            pb = new ProblemChoco();
-            // } else if(dp[0].equalsIgnoreCase("choco2")){
-            // pb = new ProblemChoco2();
-        } else if (dp[0].equalsIgnoreCase("coral")) {
-            pb = new ProblemCoral();
-        } else if (dp[0].equalsIgnoreCase("iasolver")) {
-            pb = new ProblemIAsolver();
-        } else if (dp[0].equalsIgnoreCase("cvc3")) {
-            pb = new ProblemCVC3();
-        } else if (dp[0].equalsIgnoreCase("cvc3bitvec")) {
-            pb = new ProblemCVC3BitVector();
-        } else if (dp[0].equalsIgnoreCase("yices")) {
-            pb = new ProblemYices();
-        } else if (dp[0].equalsIgnoreCase("z3")) {
-            pb = new ProblemZ3();
-        } else if (dp[0].equalsIgnoreCase("z3inc")) {
-            pb = new ProblemZ3Incremental();
-        } else if (dp[0].equalsIgnoreCase("z3bitvectorinc")) {
-            pb = new ProblemZ3BitVectorIncremental();
-        } else if (dp[0].equalsIgnoreCase("debug")) {
-            pb = new DebugSolvers(pc);
-        } else if (dp[0].equalsIgnoreCase("compare")) {
-            pb = new ProblemCompare(pc, this);
-        } else if (dp[0].equalsIgnoreCase("z3bitvector")) {
-            pb = new ProblemZ3BitVector();
-        } else if (dp[0].equalsIgnoreCase("z3optimize")) {
-            pb = new ProblemZ3Optimize();
-        }
-        // added option to have no-solving
-        // as a result symbolic execution will explore an over-approximation of the
-        // program paths
-        // equivalent to a CFG analysis
-        else if (dp[0].equalsIgnoreCase("no_solver")) {
-            return true;
-        } else
-            throw new RuntimeException(
-                    "## Error: unknown decision procedure symbolic.dp=" + dp[0] + "\n(use choco or IAsolver or CVC3)");
-
-        /*
-         * Parse path condition to solver. Note: do not override the actual pb
-         * variable in case the result is null. The cleanup afterwards will not
-         * work otherwise and the solver gets filled up with wrong assertions,
-         * e.g. with Z3.
-         */
-        ProblemGeneral tempPb = PCParser.parse(pc, pb);
-
-        if (tempPb == null)
-            result = Boolean.FALSE;
-        else {
-            pb = tempPb;
-
-            // YN: z3 optimize
-            if (Observations.lastObservedSymbolicExpression != null) {
-                if (pb instanceof ProblemZ3Optimize) {
-                    ((ProblemZ3Optimize) pb).maximize(
-                            PCParser.getExpression((IntegerExpression) Observations.lastObservedSymbolicExpression));
+        } else {
+            for(String s : dp) {
+                if (s.equalsIgnoreCase("choco")) {
+                    solvers.add(new ProblemChoco());
+                    // } else if(dp[0].equalsIgnoreCase("choco2")){
+                    // pb = new ProblemChoco2();
+                } else if (s.equalsIgnoreCase("coral")) {
+                    solvers.add(new ProblemCoral());
+                } else if (s.equalsIgnoreCase("iasolver")) {
+                    solvers.add(new ProblemIAsolver());
+                } else if (s.equalsIgnoreCase("cvc3")) {
+                    solvers.add(new ProblemCVC3());
+                } else if (s.equalsIgnoreCase("cvc3bitvec")) {
+                    solvers.add(new ProblemCVC3BitVector());
+                } else if (s.equalsIgnoreCase("yices")) {
+                    solvers.add(new ProblemYices());
+                } else if (s.equalsIgnoreCase("z3")) {
+                    solvers.add(new ProblemZ3());
+                } else if (s.equalsIgnoreCase("z3inc")) {
+                    solvers.add(new ProblemZ3Incremental());
+                } else if (s.equalsIgnoreCase("z3bitvectorinc")) {
+                    solvers.add(new ProblemZ3BitVectorIncremental());
+                } else if (s.equalsIgnoreCase("debug")) {
+                    solvers.add(new DebugSolvers(pc));
+                } else if (s.equalsIgnoreCase("compare")) {
+                    solvers.add(new ProblemCompare(pc, this));
+                } else if (s.equalsIgnoreCase("z3bitvector")) {
+                    solvers.add(new ProblemZ3BitVector());
+                } else if (s.equalsIgnoreCase("z3optimize")) {
+                    solvers.add(new ProblemZ3Optimize());
                 }
+                // added option to have no-solving
+                // as a result symbolic execution will explore an over-approximation of the
+                // program paths
+                // equivalent to a CFG analysis
+                else if (s.equalsIgnoreCase("no_solver")) {
+                    return true;
+                } else
+                    throw new RuntimeException(
+                            "## Error: unknown decision procedure symbolic.dp=" + dp[0] + "\n(use choco or IAsolver or CVC3)");
+            }
+        }
+
+
+
+        for(int i = 0; i < solvers.size(); i++) {
+            pb = solvers.get(i);
+
+            if (SymbolicInstructionFactory.debugMode) {
+                System.out.println("Using solver: " + pb.getClass().getSimpleName());
             }
 
-            result = pb.solve();
-        }
+            ProblemGeneral tempPb = PCParser.parse(pc, pb);
 
-        if (SymbolicInstructionFactory.debugMode)
-            System.out.println("numeric PC: " + pc + " -> " + result + "\n");
+            if (tempPb == null)
+                continue;
+            else {
+                pb = tempPb;
 
-        if (SymbolicInstructionFactory.regressMode) {
-            String output = "##NUMERIC PC: ";
-            output = output + (result == Boolean.TRUE ? "(SOLVED)" : "(UNSOLVED)");
-            output = output + " " + pc;
-            System.out.println(output);
-        }
+                // YN: z3 optimize
+                if (Observations.lastObservedSymbolicExpression != null) {
+                    if (pb instanceof ProblemZ3Optimize) {
+                        ((ProblemZ3Optimize) pb).maximize(
+                                PCParser.getExpression((IntegerExpression) Observations.lastObservedSymbolicExpression));
+                    }
+                }
 
-        if (result == null) {
-            return false;
-        }
-        if (result == Boolean.TRUE) {
-            return true;
-        } else {
-            return false;
-        }
+                result = pb.solve();
+            }
 
+            if (SymbolicInstructionFactory.debugMode)
+                System.out.println("numeric PC: " + pc + " -> " + result + "\n");
+
+            if (SymbolicInstructionFactory.regressMode) {
+                String output = "##NUMERIC PC: ";
+                output = output + (result == Boolean.TRUE ? "(SOLVED)" : "(UNSOLVED)");
+                output = output + " " + pc;
+                System.out.println(output);
+            }
+
+            if (result == null) {
+                continue;
+            }
+            if (result == Boolean.TRUE) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public boolean isSatisfiableGreen(PathCondition pc) {
@@ -187,17 +196,21 @@ public class SymbolicConstraintsGeneral {
     }
 
     public void cleanup() {
-        if (pb instanceof ProblemCVC3) {
-            ((ProblemCVC3) pb).cleanup();
-        } else if (pb instanceof ProblemCoral) {
-            ((ProblemCoral) pb).cleanup();
-        } else if (pb instanceof ProblemZ3) {
-            ((ProblemZ3) pb).cleanup();
-        } else if (pb instanceof ProblemZ3BitVector) {
-            ((ProblemZ3BitVector) pb).cleanup();
-        } else if (pb instanceof ProblemZ3Optimize) {
-            ((ProblemZ3Optimize) pb).cleanup();
+        for(int i = 0; i < solvers.size(); i++) {
+            ProblemGeneral solver = solvers.get(i);
+            if (solver instanceof ProblemCVC3) {
+                ((ProblemCVC3) solver).cleanup();
+            } else if (solver instanceof ProblemCoral) {
+                ((ProblemCoral) solver).cleanup();
+            } else if (solver instanceof ProblemZ3) {
+                ((ProblemZ3) solver).cleanup();
+            } else if (solver instanceof ProblemZ3BitVector) {
+                ((ProblemZ3BitVector) solver).cleanup();
+            } else if (solver instanceof ProblemZ3Optimize) {
+                ((ProblemZ3Optimize) solver).cleanup();
+            }
         }
+
     }
 
     public boolean solve(PathCondition pc) {

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/numeric/solvers/IncrementalListener.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/numeric/solvers/IncrementalListener.java
@@ -27,18 +27,21 @@ import gov.nasa.jpf.symbc.numeric.PCChoiceGenerator;
 import gov.nasa.jpf.vm.ChoiceGenerator;
 import gov.nasa.jpf.vm.VM;
 
+import java.util.Set;
+
 public class IncrementalListener extends PropertyListenerAdapter {
   
   public static IncrementalSolver solver;
   
   public IncrementalListener(Config config, JPF jpf) {
-    String stringDp = SymbolicInstructionFactory.dp[0];
-    if(stringDp.equalsIgnoreCase("z3inc")){
+//    TODO: What if both are in symbolic.dp
+    Set<String> dpSet = SymbolicInstructionFactory.dpSet;
+    if(dpSet.contains("z3inc")){
       solver = new ProblemZ3Incremental();
-    }  else if(stringDp.equalsIgnoreCase("z3bitvectorinc")){
+    }  else if(dpSet.contains("z3bitvectorinc")){
       solver = new ProblemZ3BitVectorIncremental();
     } else {
-      System.err.println("Trying to use incremental listener, but solver " + stringDp + " does not support incremental solving (try z3inc or z3bitvectorinc)");
+      System.err.println("Trying to use incremental listener, but no solver in symbolic.dp supports incremental solving (try z3inc or z3bitvectorinc)");
       jpf.removeListener(this);
     }
 

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/numeric/solvers/NoSolverSucceededException.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/numeric/solvers/NoSolverSucceededException.java
@@ -1,0 +1,9 @@
+package gov.nasa.jpf.symbc.numeric.solvers;
+
+public class NoSolverSucceededException extends RuntimeException {
+
+    public NoSolverSucceededException(String message) {
+        super(message);
+    }
+
+}

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/numeric/solvers/ProblemCVC3.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/numeric/solvers/ProblemCVC3.java
@@ -94,7 +94,11 @@ public class ProblemCVC3 extends ProblemGeneral {
 	//if min or max are passed in as null objects to the vc
 	//it will use minus and plus infinity
 	public Object makeIntVar(String name, long min, long max) {
-		assert(min>=Integer.MIN_VALUE && max<=Integer.MAX_VALUE);
+
+		if (min < Integer.MIN_VALUE || max > Integer.MAX_VALUE) {
+			throw new IllegalArgumentException("## Error CVC3: min and max must be within Integer range");
+		}
+
 		try{
 			Type sType = vc.subrangeType(vc.ratExpr((int) min),
                     vc.ratExpr((int) max));

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/numeric/solvers/ProblemCVC3.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/numeric/solvers/ProblemCVC3.java
@@ -72,6 +72,7 @@ public class ProblemCVC3 extends ProblemGeneral {
 			if(vc != null) vc.delete();
 	        flags = ValidityChecker.createFlags(null);
 	        flags.setFlag("dagify-exprs",false);
+//			flags.setFlag("timeout",1000);
 	        vc = ValidityChecker.create(flags);
 	       // System.out.println("validity checker is initialized");
 		} catch (Exception e) {
@@ -774,15 +775,13 @@ public class ProblemCVC3 extends ProblemGeneral {
 	            //System.out.println("Unsatisfiable (Valid)\n");
 				vc.pop();
 	            return false;
-	        }
-	        else if (result == SatResult.SATISFIABLE) {
+	        } else if (result == SatResult.SATISFIABLE) {
 	        	model = vc.getConcreteModel();
 	        	vc.pop();
 	           // System.out.println("Satisfiable (Invalid)\n");
 	            return true;
-	        }else{
-	        	vc.pop();
-	        	return false;
+	        } else {
+	        	throw new RuntimeException("## Error CVC3: Unexpected CVC3 status: " + result);
 	        }
         }catch(Exception e){
         	e.printStackTrace();

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/numeric/solvers/ProblemCVC3.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/numeric/solvers/ProblemCVC3.java
@@ -112,25 +112,21 @@ public class ProblemCVC3 extends ProblemGeneral {
 	}
 
 
-
 	public Object makeRealVar(String name, double min, double max) {
-
-		//WARNING: need to downcast double to int - I don't see
-		// a way in CVC3 to create a sub-range for real types
-		//other choice is not to bound and use vc.realType() to
-		//create the expression
-		int minInt = (int)min;
-		int maxInt = (int)max;
-		try{
-			//Expr x = vc.varExpr(name, vc.realType());
-			Type sType = vc.subrangeType(vc.ratExpr(minInt),
-                    vc.ratExpr(maxInt));
-			return vc.varExpr(name, sType);
+		try {
+			Expr x = vc.varExpr(name,vc.realType());
+			// Convert to plain decimal string to avoid scientific notation
+			// (e.g., 1.0E-10 → "0.0000000001")
+			String minDecimalStr = java.math.BigDecimal.valueOf(min).toPlainString();
+			String maxDecimalStr = java.math.BigDecimal.valueOf(max).toPlainString();
+			Expr upperBound = vc.leExpr(x, vc.ratExpr(maxDecimalStr));
+			Expr lowerBound = vc.geExpr(x, vc.ratExpr(minDecimalStr));
+			this.post(vc.andExpr(lowerBound, upperBound));
+            return x;
 		} catch (Exception e) {
 			e.printStackTrace();
 			throw new RuntimeException("## Error CVC3: Exception caught in CVC3 JNI: \n" + e);
-
-	    }
+		}
 	}
 
 	public Object eq(long value, Object exp){
@@ -767,7 +763,7 @@ public class ProblemCVC3 extends ProblemGeneral {
 			if (pb==null)
 				return true;
 			//Expr ex = test();
-			//System.out.println("Query: " + pb.toString());
+			System.out.println("Query: " + pb.toString());
 			vc.push();
 			SatResult result = vc.checkUnsat(pb);
 			//QueryResult result = vc.query(eq); //does not seem to work properly

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/numeric/solvers/ProblemChoco.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/numeric/solvers/ProblemChoco.java
@@ -57,7 +57,10 @@ public class ProblemChoco extends ProblemGeneral {
 	}
 
 	public IntDomainVar makeIntVar(String name, long min, long max) {
-		assert(min>=Integer.MIN_VALUE && max<=Integer.MAX_VALUE);
+		// Choco recommends staying within Integer.MIN_VALUE / 100 and Integer.MAX_VALUE / 100
+		// to avoid arithmetic overflows during constraint propagation.
+		if(min < (Integer.MIN_VALUE / 100)) min = Integer.MIN_VALUE / 100;
+		if(max > (Integer.MAX_VALUE / 100)) max = Integer.MAX_VALUE / 100;
 		return pb.makeBoundIntVar(name, (int) min, (int) max);
 	}
 
@@ -324,8 +327,12 @@ public class ProblemChoco extends ProblemGeneral {
         pb.getSolver().setTimeLimit(ProblemChoco.timeBound);
 
         Boolean result = pb.solve();
-//        if (result == null)
- //       	System.out.println("Choco PC"+pb.pretty());
+
+		if (result == null) {
+			throw new RuntimeException("# Error: Choco returned null (possibly due to timeout).\n" +
+					"Time limit: " + ProblemChoco.timeBound + "\n" +
+					"Problem state:\n" + pb.pretty());
+		}
 
 		return result;
 	}

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/numeric/solvers/ProblemChoco.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/numeric/solvers/ProblemChoco.java
@@ -59,8 +59,12 @@ public class ProblemChoco extends ProblemGeneral {
 	public IntDomainVar makeIntVar(String name, long min, long max) {
 		// Choco recommends staying within Integer.MIN_VALUE / 100 and Integer.MAX_VALUE / 100
 		// to avoid arithmetic overflows during constraint propagation.
-		if(min < (Integer.MIN_VALUE / 100)) min = Integer.MIN_VALUE / 100;
-		if(max > (Integer.MAX_VALUE / 100)) max = Integer.MAX_VALUE / 100;
+		if (min < (Integer.MIN_VALUE / 100) || max > (Integer.MAX_VALUE / 100)) {
+			throw new IllegalArgumentException(String.format(
+					"## Error Choco Invalid bounds for '%s': [%d, %d] exceed safe range [%d, %d] for Choco.",
+					name, min, max, Integer.MIN_VALUE / 100, Integer.MAX_VALUE / 100
+			));
+		}
 		return pb.makeBoundIntVar(name, (int) min, (int) max);
 	}
 

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/numeric/solvers/ProblemCoral.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/numeric/solvers/ProblemCoral.java
@@ -652,7 +652,7 @@ public class ProblemCoral extends ProblemGeneral {
 	 */
 	public Boolean solve() {
 		Solver solver = solverKind.get();
-		Boolean result = null;
+		Boolean result = false;
 		try {
 			sol = solveIt(pc, solver);
 			/**
@@ -664,6 +664,8 @@ public class ProblemCoral extends ProblemGeneral {
 				result = true;
 			}
 		} catch (Exception e) {
+			e.printStackTrace();
+        	throw new RuntimeException("## Error Coral: " + e);
 		}
 //		finally {
 //			System.out.printf(">>> %s %s %s\n", pc.toString(), sol, result);

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/numeric/solvers/ProblemZ3.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/numeric/solvers/ProblemZ3.java
@@ -130,8 +130,12 @@ public class ProblemZ3 extends ProblemGeneral {
 				return expr;
 			} else {
 				RealExpr expr = ctx.mkRealConst(name);
-				solver.add(ctx.mkGe(expr, ctx.mkReal("" + min)));
-				solver.add(ctx.mkLe(expr, ctx.mkReal("" + max)));
+				// Convert to plain decimal string to avoid scientific notation
+				// (e.g., 1.0E-10 → "0.0000000001")
+				String minDecimalStr = java.math.BigDecimal.valueOf(min).toPlainString();
+				String maxDecimalStr = java.math.BigDecimal.valueOf(max).toPlainString();
+				solver.add(ctx.mkGe(expr, ctx.mkReal(minDecimalStr)));
+				solver.add(ctx.mkLe(expr, ctx.mkReal(maxDecimalStr)));
 				return expr;
 			}
 		} catch (Exception e) {
@@ -668,7 +672,7 @@ public class ProblemZ3 extends ProblemGeneral {
     }
 
 	public Boolean solve() {
-//		System.out.println(solver.toString());
+		System.out.println(solver.toString());
         try {
 			Status status = solver.check();
 			switch (status) {

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/numeric/solvers/ProblemZ3.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/numeric/solvers/ProblemZ3.java
@@ -95,6 +95,9 @@ public class ProblemZ3 extends ProblemGeneral {
 		Z3Wrapper z3 = Z3Wrapper.getInstance();
 		solver = z3.getSolver();
 		ctx = z3.getCtx();
+//		Params p = ctx.mkParams();
+//		p.add("timeout", 1000);
+//		solver.setParameters(p);
 		solver.push();
 		useFpForReals = SymbolicInstructionFactory.fp;
 	}
@@ -665,12 +668,17 @@ public class ProblemZ3 extends ProblemGeneral {
     }
 
 	public Boolean solve() {
+//		System.out.println(solver.toString());
         try {
-            if (Status.SATISFIABLE == solver.check()) {
-                return true;
-            } else {
-                return false;
-            }
+			Status status = solver.check();
+			switch (status) {
+				case SATISFIABLE:
+					return true;
+				case UNSATISFIABLE:
+					return false;
+				default:
+					throw new RuntimeException("## Error Z3: Unexpected Z3 status: " + status + " possibly due to timeout.");
+			}
         } catch(Exception e){
         	e.printStackTrace();
         	throw new RuntimeException("## Error Z3: " + e);


### PR DESCRIPTION
-- Allow specifying multiple solvers in symbolic.dp, separated by commas

-- refactor SymbolicConstraintsGeneral to support a list of solvers that run sequentially in the order

-- Add UnsatExample for testing