### PR TITLE
fix: improve parsing of Real Symbolic Variables 

### DIFF
--- a/jpf-symbc/src/examples/DoubleTest.java
+++ b/jpf-symbc/src/examples/DoubleTest.java
@@ -1,0 +1,25 @@
+import gov.nasa.jpf.symbc.Debug;
+
+public class DoubleTest {
+    public static void main(String[] args) {
+        double a = Debug.makeSymbolicReal("a");
+        double b = Debug.makeSymbolicReal("b");
+        test(a, b);
+    }
+
+    public static void test(double a, double b) {
+        if(a > b) {
+            if(a == Double.MAX_VALUE) {
+                System.out.println("P001");
+            }
+
+            if(b == -Double.MAX_VALUE) {
+                System.out.println("P002");
+            }
+        }
+
+        if(a < 0 || b < 0) {
+            System.out.println("F001");
+        }
+    }
+}

--- a/jpf-symbc/src/examples/DoubleTest.jpf
+++ b/jpf-symbc/src/examples/DoubleTest.jpf
@@ -1,0 +1,9 @@
+target=DoubleTest
+classpath=${jpf-symbc}/build/examples
+sourcepath=${jpf-symbc}/src/examples
+symbolic.method = ArrayTest.test(sym#sym)
+
+symbolic.dp=z3
+#listener = .symbc.SymbolicListener
+
+#symbolic.debug=true

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/numeric/MinMax.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/numeric/MinMax.java
@@ -112,7 +112,8 @@ public class MinMax {
 	/**
 	 * Lower bound on symbolic real variables.
 	 */
-	private static double minDouble = Double.MIN_VALUE; //-8;
+	// Double.MIN_VALUE represents the smallest positive value, not the most negative one
+	private static double minDouble = -Double.MAX_VALUE; //-8;
 
 	/**
 	 * Upper bound on symbolic real variables.

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/numeric/solvers/ProblemCVC3.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/numeric/solvers/ProblemCVC3.java
@@ -41,6 +41,7 @@ package gov.nasa.jpf.symbc.numeric.solvers;
 // still needs a lot of work: do not use!
 
 
+import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.List;
 
@@ -109,23 +110,16 @@ public class ProblemCVC3 extends ProblemGeneral {
 
 
 	public Object makeRealVar(String name, double min, double max) {
-
-		//WARNING: need to downcast double to int - I don't see
-		// a way in CVC3 to create a sub-range for real types
-		//other choice is not to bound and use vc.realType() to
-		//create the expression
-		int minInt = (int)min;
-		int maxInt = (int)max;
-		try{
-			//Expr x = vc.varExpr(name, vc.realType());
-			Type sType = vc.subrangeType(vc.ratExpr(minInt),
-                    vc.ratExpr(maxInt));
-			return vc.varExpr(name, sType);
+		try {
+			Expr x = vc.varExpr(name,vc.realType());
+			Expr upperBound = vc.leExpr(x, vc.ratExpr(toPlainDecimalString(max)));
+			Expr lowerBound = vc.geExpr(x, vc.ratExpr(toPlainDecimalString(min)));
+			this.post(vc.andExpr(lowerBound, upperBound));
+			return x;
 		} catch (Exception e) {
 			e.printStackTrace();
 			throw new RuntimeException("## Error CVC3: Exception caught in CVC3 JNI: \n" + e);
-
-	    }
+		}
 	}
 
 	public Object eq(long value, Object exp){
@@ -160,7 +154,7 @@ public class ProblemCVC3 extends ProblemGeneral {
 
 	public Object eq(double value, Object exp){
 		try{
-			return  vc.eqExpr(vc.ratExpr(Double.toString(value), base), (Expr)exp);
+			return  vc.eqExpr(vc.ratExpr(toPlainDecimalString(value), base), (Expr)exp);
 		} catch (Exception e) {
 			e.printStackTrace();
 			throw new RuntimeException("## Error CVC3: Exception caught in CVC3 JNI: \n" + e);
@@ -170,7 +164,7 @@ public class ProblemCVC3 extends ProblemGeneral {
 
 	public Object eq(Object exp, double value){
 		try{
-			return  vc.eqExpr((Expr)exp, vc.ratExpr(Double.toString(value), base));
+			return  vc.eqExpr((Expr)exp, vc.ratExpr(toPlainDecimalString(value), base));
 		} catch (Exception e) {
 			e.printStackTrace();
 			throw new RuntimeException("## Error CVC3: Exception caught in CVC3 JNI: \n" + e);
@@ -220,7 +214,7 @@ public class ProblemCVC3 extends ProblemGeneral {
 
 	public Object neq(double value, Object exp){
 		try{
-			return  vc.notExpr(vc.eqExpr(vc.ratExpr(Double.toString(value), base), (Expr)exp));
+			return  vc.notExpr(vc.eqExpr(vc.ratExpr(toPlainDecimalString(value), base), (Expr)exp));
 		} catch (Exception e) {
 			e.printStackTrace();
 			throw new RuntimeException("## Error CVC3: Exception caught in CVC3 JNI: \n" + e);
@@ -230,7 +224,7 @@ public class ProblemCVC3 extends ProblemGeneral {
 
 	public Object neq(Object exp, double value){
 		try{
-			return  vc.notExpr(vc.eqExpr((Expr)exp, vc.ratExpr(Double.toString(value), base)));
+			return  vc.notExpr(vc.eqExpr((Expr)exp, vc.ratExpr(toPlainDecimalString(value), base)));
 		} catch (Exception e) {
 			e.printStackTrace();
 			throw new RuntimeException("## Error CVC3: Exception caught in CVC3 JNI: \n" + e);
@@ -270,7 +264,7 @@ public class ProblemCVC3 extends ProblemGeneral {
 
 	public Object leq(double value, Object exp){
 		try{
-			return  vc.leExpr(vc.ratExpr(Double.toString(value), base), (Expr)exp);
+			return  vc.leExpr(vc.ratExpr(toPlainDecimalString(value), base), (Expr)exp);
 		} catch (Exception e) {
 			e.printStackTrace();
 			throw new RuntimeException("## Error CVC3: Exception caught in CVC3 JNI: \n" + e);
@@ -280,7 +274,7 @@ public class ProblemCVC3 extends ProblemGeneral {
 
 	public Object leq(Object exp, double value){
 		try{
-			return  vc.leExpr((Expr)exp, vc.ratExpr(Double.toString(value), base));
+			return  vc.leExpr((Expr)exp, vc.ratExpr(toPlainDecimalString(value), base));
 		} catch (Exception e) {
 			e.printStackTrace();
 			throw new RuntimeException("## Error CVC3: Exception caught in CVC3 JNI: \n" + e);
@@ -320,7 +314,7 @@ public class ProblemCVC3 extends ProblemGeneral {
 
 	public Object geq(double value, Object exp){
 		try{
-			return  vc.geExpr(vc.ratExpr(Double.toString(value), base), (Expr)exp);
+			return  vc.geExpr(vc.ratExpr(toPlainDecimalString(value), base), (Expr)exp);
 		} catch (Exception e) {
 			e.printStackTrace();
 			throw new RuntimeException("## Error CVC3: Exception caught in CVC3 JNI: \n" + e);
@@ -330,7 +324,7 @@ public class ProblemCVC3 extends ProblemGeneral {
 
 	public Object geq(Object exp, double value){
 		try{
-			return  vc.geExpr((Expr)exp, vc.ratExpr(Double.toString(value), base));
+			return  vc.geExpr((Expr)exp, vc.ratExpr(toPlainDecimalString(value), base));
 		} catch (Exception e) {
 			e.printStackTrace();
 			throw new RuntimeException("## Error CVC3: Exception caught in CVC3 JNI: \n" + e);
@@ -370,7 +364,7 @@ public class ProblemCVC3 extends ProblemGeneral {
 
 	public Object lt(double value, Object exp){
 		try{
-			return  vc.ltExpr(vc.ratExpr(Double.toString(value), base), (Expr)exp);
+			return  vc.ltExpr(vc.ratExpr(toPlainDecimalString(value), base), (Expr)exp);
 		} catch (Exception e) {
 			e.printStackTrace();
 			throw new RuntimeException("## Error CVC3: Exception caught in CVC3 JNI: \n" + e);
@@ -380,7 +374,7 @@ public class ProblemCVC3 extends ProblemGeneral {
 
 	public Object lt(Object exp, double value){
 		try{
-			return  vc.ltExpr((Expr)exp, vc.ratExpr(Double.toString(value), base));
+			return  vc.ltExpr((Expr)exp, vc.ratExpr(toPlainDecimalString(value), base));
 		} catch (Exception e) {
 			e.printStackTrace();
 			throw new RuntimeException("## Error CVC3: Exception caught in CVC3 JNI: \n" + e);
@@ -431,7 +425,7 @@ public class ProblemCVC3 extends ProblemGeneral {
 
 	public Object gt(double value, Object exp){
 		try{
-			return  vc.gtExpr(vc.ratExpr(Double.toString(value), base), (Expr)exp);
+			return  vc.gtExpr(vc.ratExpr(toPlainDecimalString(value), base), (Expr)exp);
 		} catch (Exception e) {
 			e.printStackTrace();
 			throw new RuntimeException("## Error CVC3: Exception caught in CVC3 JNI: \n" + e);
@@ -441,7 +435,7 @@ public class ProblemCVC3 extends ProblemGeneral {
 
 	public Object gt(Object exp, double value){
 		try{
-			return  vc.gtExpr((Expr)exp, vc.ratExpr(Double.toString(value), base));
+			return  vc.gtExpr((Expr)exp, vc.ratExpr(toPlainDecimalString(value), base));
 		} catch (Exception e) {
 			e.printStackTrace();
 			throw new RuntimeException("## Error CVC3: Exception caught in CVC3 JNI: \n" + e);
@@ -481,7 +475,7 @@ public class ProblemCVC3 extends ProblemGeneral {
 
 	public Object plus(double value, Object exp) {
 		try{
-			return  vc.plusExpr(vc.ratExpr(Double.toString(value), base), (Expr)exp);
+			return  vc.plusExpr(vc.ratExpr(toPlainDecimalString(value), base), (Expr)exp);
 		} catch (Exception e) {
 			e.printStackTrace();
 			throw new RuntimeException("## Error CVC3: Exception caught in CVC3 JNI: \n" + e);
@@ -490,7 +484,7 @@ public class ProblemCVC3 extends ProblemGeneral {
 
 	public Object plus(Object exp, double value) {
 		try{
-			return  vc.plusExpr((Expr)exp, vc.ratExpr(Double.toString(value), base));
+			return  vc.plusExpr((Expr)exp, vc.ratExpr(toPlainDecimalString(value), base));
 		} catch (Exception e) {
 			e.printStackTrace();
 			throw new RuntimeException("## Error CVC3: Exception caught in CVC3 JNI: \n" + e);
@@ -526,7 +520,7 @@ public class ProblemCVC3 extends ProblemGeneral {
 
 	public Object minus(double value, Object exp) {
 		try{
-			return  vc.minusExpr(vc.ratExpr(Double.toString(value), base), (Expr)exp);
+			return  vc.minusExpr(vc.ratExpr(toPlainDecimalString(value), base), (Expr)exp);
 		} catch (Exception e) {
 			e.printStackTrace();
 			throw new RuntimeException("## Error CVC3: Exception caught in CVC3 JNI: \n" + e);
@@ -535,7 +529,7 @@ public class ProblemCVC3 extends ProblemGeneral {
 
 	public Object minus(Object exp, double value) {
 		try{
-			return  vc.minusExpr((Expr)exp, vc.ratExpr(Double.toString(value), base));
+			return  vc.minusExpr((Expr)exp, vc.ratExpr(toPlainDecimalString(value), base));
 		} catch (Exception e) {
 			e.printStackTrace();
 			throw new RuntimeException("## Error CVC3: Exception caught in CVC3 JNI: \n" + e);
@@ -570,7 +564,7 @@ public class ProblemCVC3 extends ProblemGeneral {
 	}
 	public Object mult(double value, Object exp) {
 		try{
-			return  vc.multExpr(vc.ratExpr(Double.toString(value), base), (Expr)exp);
+			return  vc.multExpr(vc.ratExpr(toPlainDecimalString(value), base), (Expr)exp);
 		} catch (Exception e) {
 			e.printStackTrace();
 			throw new RuntimeException("## Error CVC3: Exception caught in CVC3 JNI: \n" + e);
@@ -578,7 +572,7 @@ public class ProblemCVC3 extends ProblemGeneral {
 	}
 	public Object mult(Object exp, double value) {
 		try{
-			return  vc.multExpr((Expr)exp, vc.ratExpr(Double.toString(value), base));
+			return  vc.multExpr((Expr)exp, vc.ratExpr(toPlainDecimalString(value), base));
 		} catch (Exception e) {
 			e.printStackTrace();
 			throw new RuntimeException("## Error CVC3: Exception caught in CVC3 JNI: \n" + e);
@@ -615,7 +609,7 @@ public class ProblemCVC3 extends ProblemGeneral {
 	}
 	public Object div(double value, Object exp) {
 		try{
-			return  vc.divideExpr(vc.ratExpr(Double.toString(value), base), (Expr)exp);
+			return  vc.divideExpr(vc.ratExpr(toPlainDecimalString(value), base), (Expr)exp);
 		} catch (Exception e) {
 			e.printStackTrace();
 			throw new RuntimeException("## Error CVC3: Exception caught in CVC3 JNI: \n" + e);
@@ -623,7 +617,7 @@ public class ProblemCVC3 extends ProblemGeneral {
 	}
 	public Object div(Object exp, double value) {
 		try{
-			return  vc.divideExpr((Expr)exp, vc.ratExpr(Double.toString(value), base));
+			return  vc.divideExpr((Expr)exp, vc.ratExpr(toPlainDecimalString(value), base));
 		} catch (Exception e) {
 			e.printStackTrace();
 			throw new RuntimeException("## Error CVC3: Exception caught in CVC3 JNI: \n" + e);
@@ -911,6 +905,12 @@ public class ProblemCVC3 extends ProblemGeneral {
 	public Object rem(Object exp1, long exp2) {
 		// TODO Auto-generated method stub
 		return null;
+	}
+
+	// Convert to plain decimal string to avoid scientific notation
+	// (e.g., 1.0E-10 → "0.0000000001")
+	private String toPlainDecimalString(double val) {
+		return BigDecimal.valueOf(val).toPlainString();
 	}
 
 }

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/numeric/solvers/ProblemZ3.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/numeric/solvers/ProblemZ3.java
@@ -38,6 +38,7 @@
 package gov.nasa.jpf.symbc.numeric.solvers;
 
 import java.io.PrintWriter;
+import java.math.BigDecimal;
 import java.util.*;
 
 //TODO: problem: we do not distinguish between ints and reals?
@@ -127,8 +128,8 @@ public class ProblemZ3 extends ProblemGeneral {
 				return expr;
 			} else {
 				RealExpr expr = ctx.mkRealConst(name);
-				solver.add(ctx.mkGe(expr, ctx.mkReal("" + min)));
-				solver.add(ctx.mkLe(expr, ctx.mkReal("" + max)));
+				solver.add(ctx.mkGe(expr, ctx.mkReal(toPlainDecimalString(min))));
+				solver.add(ctx.mkLe(expr, ctx.mkReal(toPlainDecimalString(max))));
 				return expr;
 			}
 		} catch (Exception e) {
@@ -692,7 +693,7 @@ public class ProblemZ3 extends ProblemGeneral {
 			if (useFpForReals) {
 				return ctx.mkFPEq(ctx.mkFPNumeral(value, ctx.mkFPSort64()), (FPExpr) exp);
 			} else {
-				return ctx.mkEq(ctx.mkReal("" + value), (Expr) exp);
+				return ctx.mkEq(ctx.mkReal(toPlainDecimalString(value)), (Expr) exp);
 			}
 		} catch (Exception e) {
 			e.printStackTrace();
@@ -706,7 +707,7 @@ public class ProblemZ3 extends ProblemGeneral {
 			if (useFpForReals) {
 				return ctx.mkFPEq((FPExpr) exp, ctx.mkFPNumeral(value, ctx.mkFPSort64()));
 			} else {
-				return ctx.mkEq((Expr) exp, ctx.mkReal("" + value));
+				return ctx.mkEq((Expr) exp, ctx.mkReal(toPlainDecimalString(value)));
 			}
 		} catch (Exception e) {
 			e.printStackTrace();
@@ -720,7 +721,7 @@ public class ProblemZ3 extends ProblemGeneral {
 			if (useFpForReals) {
 				return ctx.mkNot(ctx.mkFPEq(ctx.mkFPNumeral(value, ctx.mkFPSort64()), (FPExpr) exp));
 			} else {
-				return ctx.mkNot(ctx.mkEq(ctx.mkReal("" + value), (Expr) exp));
+				return ctx.mkNot(ctx.mkEq(ctx.mkReal(toPlainDecimalString(value)), (Expr) exp));
 			}
 		} catch (Exception e) {
 			e.printStackTrace();
@@ -734,7 +735,7 @@ public class ProblemZ3 extends ProblemGeneral {
 			if (useFpForReals) {
 				return ctx.mkNot(ctx.mkFPEq((FPExpr) exp, ctx.mkFPNumeral(value, ctx.mkFPSort64())));
 			} else {
-				return ctx.mkNot(ctx.mkEq((Expr) exp, ctx.mkReal("" + value)));
+				return ctx.mkNot(ctx.mkEq((Expr) exp, ctx.mkReal(toPlainDecimalString(value))));
 			}
 		} catch (Exception e) {
 			e.printStackTrace();
@@ -748,7 +749,7 @@ public class ProblemZ3 extends ProblemGeneral {
 			if (useFpForReals) {
 				return ctx.mkFPLEq(ctx.mkFPNumeral(value, ctx.mkFPSort64()), (FPExpr) exp);
 			} else {
-				return ctx.mkLe(ctx.mkReal("" + value), (ArithExpr) exp);
+				return ctx.mkLe(ctx.mkReal(toPlainDecimalString(value)), (ArithExpr) exp);
 			}
 		} catch (Exception e) {
 			e.printStackTrace();
@@ -762,7 +763,7 @@ public class ProblemZ3 extends ProblemGeneral {
 			if (useFpForReals) {
 				return ctx.mkFPLEq((FPExpr) exp, ctx.mkFPNumeral(value, ctx.mkFPSort64()));
 			} else {
-				return ctx.mkLe((ArithExpr) exp, ctx.mkReal("" + value));
+				return ctx.mkLe((ArithExpr) exp, ctx.mkReal(toPlainDecimalString(value)));
 			}
 		} catch (Exception e) {
 			e.printStackTrace();
@@ -776,7 +777,7 @@ public class ProblemZ3 extends ProblemGeneral {
 			if (useFpForReals) {
 				return ctx.mkFPGEq(ctx.mkFPNumeral(value, ctx.mkFPSort64()), (FPExpr) exp);
 			} else {
-				return ctx.mkGe(ctx.mkReal("" + value), (ArithExpr) exp);
+				return ctx.mkGe(ctx.mkReal(toPlainDecimalString(value)), (ArithExpr) exp);
 			}
 		} catch (Exception e) {
 			e.printStackTrace();
@@ -790,7 +791,7 @@ public class ProblemZ3 extends ProblemGeneral {
 			if (useFpForReals) {
 				return ctx.mkFPGEq((FPExpr) exp, ctx.mkFPNumeral(value, ctx.mkFPSort64()));
 			} else {
-				return ctx.mkGe((ArithExpr) exp, ctx.mkReal("" + value));
+				return ctx.mkGe((ArithExpr) exp, ctx.mkReal(toPlainDecimalString(value)));
 			}
 		} catch (Exception e) {
 			e.printStackTrace();
@@ -804,7 +805,7 @@ public class ProblemZ3 extends ProblemGeneral {
 			if (useFpForReals) {
 				return ctx.mkFPLt(ctx.mkFPNumeral(value, ctx.mkFPSort64()), (FPExpr) exp);
 			} else {
-				return ctx.mkLt(ctx.mkReal("" + value), (ArithExpr) exp);
+				return ctx.mkLt(ctx.mkReal(toPlainDecimalString(value)), (ArithExpr) exp);
 			}
 		} catch (Exception e) {
 			e.printStackTrace();
@@ -818,7 +819,7 @@ public class ProblemZ3 extends ProblemGeneral {
 			if (useFpForReals) {
 				return ctx.mkFPLt((FPExpr) exp, ctx.mkFPNumeral(value, ctx.mkFPSort64()));
 			} else {
-				return ctx.mkLt((ArithExpr) exp, ctx.mkReal("" + value));
+				return ctx.mkLt((ArithExpr) exp, ctx.mkReal(toPlainDecimalString(value)));
 			}
 		} catch (Exception e) {
 			e.printStackTrace();
@@ -832,7 +833,7 @@ public class ProblemZ3 extends ProblemGeneral {
 			if (useFpForReals) {
 				return ctx.mkFPGt(ctx.mkFPNumeral(value, ctx.mkFPSort64()), (FPExpr) exp);
 			} else {
-				return ctx.mkGt(ctx.mkReal("" + value), (ArithExpr) exp);
+				return ctx.mkGt(ctx.mkReal(toPlainDecimalString(value)), (ArithExpr) exp);
 			}
 		} catch (Exception e) {
 			e.printStackTrace();
@@ -846,7 +847,7 @@ public class ProblemZ3 extends ProblemGeneral {
 			if (useFpForReals) {
 				return ctx.mkFPGt((FPExpr) exp, ctx.mkFPNumeral(value, ctx.mkFPSort64()));
 			} else {
-				return ctx.mkGt((ArithExpr) exp, ctx.mkReal("" + value));
+				return ctx.mkGt((ArithExpr) exp, ctx.mkReal(toPlainDecimalString(value)));
 			}
 		} catch (Exception e) {
 			e.printStackTrace();
@@ -860,7 +861,7 @@ public class ProblemZ3 extends ProblemGeneral {
 			if (useFpForReals) {
 				return ctx.mkFPAdd(ctx.mkFPRoundNearestTiesToEven(), ctx.mkFPNumeral(value, ctx.mkFPSort64()), (FPExpr) exp);
 			} else {
-				return ctx.mkAdd(ctx.mkReal("" + value), (ArithExpr) exp);
+				return ctx.mkAdd(ctx.mkReal(toPlainDecimalString(value)), (ArithExpr) exp);
 			}
 		} catch (Exception e) {
 			e.printStackTrace();
@@ -874,7 +875,7 @@ public class ProblemZ3 extends ProblemGeneral {
 			if (useFpForReals) {
 				return ctx.mkFPAdd(ctx.mkFPRoundNearestTiesToEven(), (FPExpr) exp, ctx.mkFPNumeral(value, ctx.mkFPSort64()));
 			} else {
-				return ctx.mkAdd((ArithExpr) exp, ctx.mkReal("" + value));
+				return ctx.mkAdd((ArithExpr) exp, ctx.mkReal(toPlainDecimalString(value)));
 			}
 		} catch (Exception e) {
 			e.printStackTrace();
@@ -888,7 +889,7 @@ public class ProblemZ3 extends ProblemGeneral {
 			if (useFpForReals) {
 				return ctx.mkFPSub(ctx.mkFPRoundNearestTiesToEven(), ctx.mkFPNumeral(value, ctx.mkFPSort64()), (FPExpr) exp);
 			} else {
-				return ctx.mkSub(ctx.mkReal("" + value), (ArithExpr) exp);
+				return ctx.mkSub(ctx.mkReal(toPlainDecimalString(value)), (ArithExpr) exp);
 			}
 		} catch (Exception e) {
 			e.printStackTrace();
@@ -902,7 +903,7 @@ public class ProblemZ3 extends ProblemGeneral {
 			if (useFpForReals) {
 				return ctx.mkFPSub(ctx.mkFPRoundNearestTiesToEven(), (FPExpr) exp, ctx.mkFPNumeral(value, ctx.mkFPSort64()));
 			} else {
-				return ctx.mkSub((ArithExpr) exp, ctx.mkReal("" + value));
+				return ctx.mkSub((ArithExpr) exp, ctx.mkReal(toPlainDecimalString(value)));
 			}
 		} catch (Exception e) {
 			e.printStackTrace();
@@ -916,7 +917,7 @@ public class ProblemZ3 extends ProblemGeneral {
 			if (useFpForReals) {
 				return ctx.mkFPMul(ctx.mkFPRoundNearestTiesToEven(), ctx.mkFPNumeral(value, ctx.mkFPSort64()), (FPExpr) exp);
 			} else {
-				return ctx.mkMul(ctx.mkReal("" + value), (ArithExpr) exp);
+				return ctx.mkMul(ctx.mkReal(toPlainDecimalString(value)), (ArithExpr) exp);
 			}
 		} catch (Exception e) {
 			e.printStackTrace();
@@ -930,7 +931,7 @@ public class ProblemZ3 extends ProblemGeneral {
 			if (useFpForReals) {
 				return ctx.mkFPMul(ctx.mkFPRoundNearestTiesToEven(), (FPExpr) exp, ctx.mkFPNumeral(value, ctx.mkFPSort64()));
 			} else {
-				return ctx.mkMul((ArithExpr) exp, ctx.mkReal("" + value));
+				return ctx.mkMul((ArithExpr) exp, ctx.mkReal(toPlainDecimalString(value)));
 			}
 		} catch (Exception e) {
 			e.printStackTrace();
@@ -944,7 +945,7 @@ public class ProblemZ3 extends ProblemGeneral {
 			if (useFpForReals) {
 				return ctx.mkFPDiv(ctx.mkFPRoundNearestTiesToEven(), ctx.mkFPNumeral(value, ctx.mkFPSort64()), (FPExpr) exp);
 			} else {
-				return ctx.mkDiv(ctx.mkReal("" + value), (ArithExpr) exp);
+				return ctx.mkDiv(ctx.mkReal(toPlainDecimalString(value)), (ArithExpr) exp);
 			}
 		} catch (Exception e) {
 			e.printStackTrace();
@@ -958,7 +959,7 @@ public class ProblemZ3 extends ProblemGeneral {
 			if (useFpForReals) {
 				return ctx.mkFPDiv(ctx.mkFPRoundNearestTiesToEven(), (FPExpr) exp, ctx.mkFPNumeral(value, ctx.mkFPSort64()));
 			} else {
-				return ctx.mkDiv((ArithExpr) exp, ctx.mkReal("" + value));
+				return ctx.mkDiv((ArithExpr) exp, ctx.mkReal(toPlainDecimalString(value)));
 			}
 		} catch (Exception e) {
 			e.printStackTrace();
@@ -1187,11 +1188,17 @@ public class ProblemZ3 extends ProblemGeneral {
     @Override
     public Object makeRealConst(double value) {
         try {
-            return ctx.mkReal("" + value);
+            return ctx.mkReal(toPlainDecimalString(value));
         } catch (Exception e) {
             e.printStackTrace();
             throw new RuntimeException("## Error Z3 : Exception caught in Z3 JNI: " + e);
         }
     }
+
+	// Convert to plain decimal string to avoid scientific notation
+	// (e.g., 1.0E-10 → "0.0000000001")
+	private String toPlainDecimalString(double val) {
+		return BigDecimal.valueOf(val).toPlainString();
+	}
 
 }


### PR DESCRIPTION

- convert double to a decimal string to avoid scientific notation in ProblemZ3 and ProblemCVC3

- refactor ProblemCVC3.makeRealVar to create a unbounded real type and then add a constraint to check for min and max instead of casting them to integers

- Use -Double.MAX_VALUE as the default minimum instead of Double.MIN_VALUE, since Double.MIN_VALUE represents the smallest positive value, not the most negative one

I have also added a DoubleTest.java and DoubleTest.jpf file to test the newely changed behavior 