### PR TITLE
Improve Witness Generation

### DIFF
--- a/jpf-symbc/src/examples/svcomp/BufferedReaderReadLine/Main.java
+++ b/jpf-symbc/src/examples/svcomp/BufferedReaderReadLine/Main.java
@@ -1,0 +1,38 @@
+package svcomp.BufferedReaderReadLine;/*
+ * Origin of the benchmark:
+ *     license: 4-clause BSD (see /java/jbmc-regression/LICENSE)
+ *     repo: https://github.com/marek-trtik/cbmc.git
+ *     branch: add_string_regression_tests
+ *     directory: regression/jbmc-strings-test-gen/BufferedReaderReadLine
+ * The benchmark was taken from the repo: 24 January 2018
+ */
+import java.io.BufferedReader;
+import java.io.StringReader;
+import org.sosy_lab.sv_benchmarks.Verifier;
+
+public class Main {
+
+  public static String check(BufferedReader br) throws Exception {
+    String s = br.readLine();
+    return s;
+  }
+
+  public static void main(String[] args) {
+    String arg = Verifier.nondetString();
+    String thisLine = null;
+    int numLines = 0;
+
+    try {
+      BufferedReader br = new BufferedReader(new StringReader(arg));
+      String line = check(br);
+      while ((thisLine = check(br)) != null) {
+        System.out.println(thisLine);
+        numLines += 1;
+      }
+    } catch (Exception e) {
+      e.printStackTrace();
+      return;
+    }
+    assert numLines > 0;
+  }
+}

--- a/jpf-symbc/src/examples/svcomp/ExSymExe28_false/Main.java
+++ b/jpf-symbc/src/examples/svcomp/ExSymExe28_false/Main.java
@@ -1,0 +1,51 @@
+package svcomp.ExSymExe28_false;/*
+ * Origin of the benchmark:
+ *     repo: https://babelfish.arc.nasa.gov/hg/jpf/jpf-symbc
+ *     branch: updated-spf
+ *     root directory: src/tests/gov/nasa/jpf/symbc
+ * The benchmark was taken from the repo: 24 January 2018
+ */
+/*
+ * Copyright (C) 2014, United States Government, as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All rights reserved.
+ *
+ * Symbolic Pathfinder (jpf-symbc) is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// package gov.nasa.jpf.symbc;
+import org.sosy_lab.sv_benchmarks.Verifier;
+
+public class Main {
+
+  public static void main(String[] args) {
+    int x = Verifier.nondetInt();
+    int y = Verifier.nondetInt();
+    Main inst = new Main();
+    inst.test(x, y, 9);
+  }
+
+  /*
+   * test IF_ICMPNE  bytecode  (Note: javac compiles "==" to IF_ICMPNE)
+   */
+  public void test(int x, int z, int r) {
+    System.out.println("Testing ExSymExe28");
+    if (z == x) System.out.println("branch FOO1");
+    else {
+      System.out.println("branch FOO2");
+      assert false;
+    }
+    if (x == r) System.out.println("branch BOO1");
+    else System.out.println("branch BOO2");
+  }
+}

--- a/jpf-symbc/src/examples/svcomp/StringConcatenation01/Main.java
+++ b/jpf-symbc/src/examples/svcomp/StringConcatenation01/Main.java
@@ -1,0 +1,29 @@
+package svcomp.StringConcatenation01;/*
+ * Origin of the benchmark:
+ *     license: 4-clause BSD (see /java/jbmc-regression/LICENSE)
+ *     repo: https://github.com/diffblue/cbmc.git
+ *     branch: develop
+ *     directory: regression/jbmc-strings/StringConcatenation01
+ * The benchmark was taken from the repo: 24 January 2018
+ */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
+public class Main {
+  public static void main(String[] args) {
+    args = new String[2];
+    args[0] = Verifier.nondetString();
+    args[1] = Verifier.nondetString();
+
+    String s1 = args[0];
+    String s2 = args[1];
+
+    assert s1.equals(args[0]);
+    assert s2.equals(args[1]);
+
+    String tmp = s1.concat(s2);
+    assert tmp.equals(args[0] + args[1]);
+
+    tmp = s1;
+    assert tmp.equals(args[0]);
+  }
+}

--- a/jpf-symbc/src/examples/svcomp/config.jpf
+++ b/jpf-symbc/src/examples/svcomp/config.jpf
@@ -57,7 +57,7 @@
 #had the problem with mod
 #target=svcomp.SatEvenOdd01.Main
 #difficult solver query.
-target=svcomp.StringIndexMethods02.Main
+#target=svcomp.StringIndexMethods02.Main
 #target=svcomp.StringValueOf06.Main
 #target=svcomp.StringCompare01.Main
 #target=svcomp.securibench.Refl2.Main
@@ -68,17 +68,19 @@ target=svcomp.StringIndexMethods02.Main
 #target=svcomp.StringCompare04.Main
 #target=svcomp.StringBuilderConstructors02.Main
 
+target=svcomp.ExSymExe28_false.Main
+
 
 classpath=${jpf-symbc}/build/examples,${jpf-symbc}/lib/com.ibm.wala.util-1.4.4-SNAPSHOT.jar
-symbolic.dp=z3bitvector
-symbolic.min_int=-2147483648
-symbolic.max_int=2147483647
-symbolic.min_double=-10000.0
-symbolic.max_double=10000.0
+symbolic.dp=choco
+symbolic.min_int=-21474836
+symbolic.max_int=21474836
+#symbolic.min_double=-10000.0
+#symbolic.max_double=10000.0
 symbolic.bvlength=64
 search.depth_limit=13
 symbolic.strings=true
-symbolic.string_dp=z3str3
+#symbolic.string_dp=z3str3
 symbolic.lazy=on
 symbolic.jrarrays=true
 veritestingMode = 5

--- a/jpf-symbc/src/main/edu/ucsb/cs/vlab/translate/smtlib/from/z3str3/Z3Translator.java
+++ b/jpf-symbc/src/main/edu/ucsb/cs/vlab/translate/smtlib/from/z3str3/Z3Translator.java
@@ -225,8 +225,12 @@ class Manager extends TranslationManager {
 			final Function<StringExpression, String> ValueOfInt = (expr) -> {
 					final DerivedStringExpression dse = (DerivedStringExpression) expr;
 					final String arg = manager.numExpr.collect((IntegerExpression) dse.oprlist[0]);
-					return "(ite ( < " + arg + " 0) (str.++ \"-\" (str.from_int (- " + arg + "))) (str.from_int " +  arg + "))";
-				};
+					if(arg.contains("bool")) {
+						return "(ite ( not (= " + arg + " 0)) \"true\" \"false\")";
+					} else {
+						return "(ite ( < " + arg + " 0) (str.++ \"-\" (str.from_int (- " + arg + "))) (str.from_int " +  arg + "))";
+					}
+			};
 
 			map(StringOrOperation.NONSYM, (expr) -> {
 				return "\"" + ((StringConstant) expr).value + "\"";

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/SymbolicListener.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/SymbolicListener.java
@@ -53,6 +53,8 @@ import gov.nasa.jpf.util.Pair;
 import java.io.*;
 import java.util.*;
 
+import static gov.nasa.jpf.symbc.witness.WitnessSymbolicState.*;
+
 public class SymbolicListener extends PropertyListenerAdapter implements PublisherExtension {
 
     /*
@@ -103,29 +105,10 @@ public class SymbolicListener extends PropertyListenerAdapter implements Publish
     // }
     // }
 
-
-    // A list to save line number and return type
-    public List<SymbolicVariableInfo> symbolicVariableInfoList = new ArrayList<>();
-
-    boolean allowMethodInvocation = false;
-    // A flag to check whether the information of symbolic variable is already parsed or not.
-    boolean interceptSymbolic = false;
-    boolean witnessAssumptionScopeIsFilled = false;
-    String fileName = "";
-    String assumptionScope = "";
-
-
     @Override
     public void propertyViolated(Search search) {
 
         VM vm = search.getVM();
-        // Path to the witness template
-        // Assume working directory is SPF
-
-        String resourcePath = "witness_template/witness_template_minimal.txt";
-
-        // Path to output directory, now it is current directory
-        String outputFilePath = "witness.graphml";
 
         ChoiceGenerator<?> cg = vm.getChoiceGenerator();
         if (!(cg instanceof PCChoiceGenerator)) {
@@ -136,18 +119,8 @@ public class SymbolicListener extends PropertyListenerAdapter implements Publish
             cg = prev_cg;
         }
 
-        Node nodeForEmptyWitness = new Node(1, 0, true);
-        String strNode = nodeForEmptyWitness.serializeNode();
-        try(InputStream inputStream = SymbolicListener.class.getClassLoader().getResourceAsStream(resourcePath)){
-            if(inputStream == null){
-                throw new IllegalArgumentException("Resource not found : " + resourcePath);
-            }
-            GraphML emptyWitness = new GraphML(inputStream, outputFilePath);
-            String headerForEmptyWitness = emptyWitness.constructHeader();
-            emptyWitness.serializeEmptyWitness(strNode, headerForEmptyWitness);
-        }catch (IOException e){
-            e.printStackTrace();
-        }
+        // serialize an empty witness
+        createEmptyWitness();
 
         if ((cg instanceof PCChoiceGenerator) && ((PCChoiceGenerator) cg).getCurrentPC() != null) {
             PathCondition pc = ((PCChoiceGenerator) cg).getCurrentPC();
@@ -176,67 +149,15 @@ public class SymbolicListener extends PropertyListenerAdapter implements Publish
             methodSummary.addPathCondition(pcPair);
             allSummaries.put(currentMethodName, methodSummary);
 
-            String strPathCondition = pc.toString();
-
             System.out.println("Property Violated: PC is " + pc.toString());
             System.out.println("Property Violated: result is  " + error);
             System.out.println("****************************");
 
-
-
-            List<Node> nodeList = new ArrayList<>();
-            List<Edge> edgeList = new ArrayList<>();
-            PathConditionParser parser = new PathConditionParser();
-            parser.parseSymVar(strPathCondition, symbolicVariableInfoList);
-            for(int i=0; i<symbolicVariableInfoList.size(); i++){
-                Node node = new Node(symbolicVariableInfoList.size(), i, false);
-                nodeList.add(node);
-                Edge edge = new Edge(i, fileName, symbolicVariableInfoList, allowMethodInvocation, assumptionScope);
-                edgeList.add(edge);
-            }
-            // Add last node that contains violation key
-            nodeList.add(new Node(symbolicVariableInfoList.size(), symbolicVariableInfoList.size(), false));
-            try(InputStream inputStream = SymbolicListener.class.getClassLoader().getResourceAsStream(resourcePath)){
-                if(inputStream == null){
-                    throw new IllegalArgumentException("Resource not found : " + resourcePath);
-                }
-                GraphML graphML = new GraphML(inputStream, outputFilePath);
-                String header = graphML.constructHeader();
-                graphML.serializeWitness(edgeList, nodeList, header);
-            }catch (IOException e){
-                e.printStackTrace();
-            }
+            populateWitnessGraph(pc);
         }
         // }
     }
 
-    /**
-     * It parses classname and filename to fill the value of assumption.scope at violation witness
-     * Both classname and filename are needed to construct the edge of the witness
-     * assumptionScope is a value of assumption.scope attribute of violation witness
-     * fileName is a value of originfile attribute of violation witness
-     */
-    public void parseAssumptionScope(ThreadInfo ti){
-        ApplicationContext app = ti.getApplicationContext();
-        String className = app.getMainClassName();
-        String[] parts = className.split("\\.");
-        fileName = parts[parts.length - 1];
-        assumptionScope = String.join(".", parts);
-    }
-
-
-
-    // Temporary object to save the information of symbolic variable
-    SymbolicVariableInfo symbolicVariableInfo = new SymbolicVariableInfo();
-
-    /**
-     * Method that extracts line number and type of symbolic variables
-     * @param md JVMInvokeInstruction object
-     */
-    public void extractSymbolicVariableInfo(JVMInvokeInstruction md){
-        symbolicVariableInfo.lineNumber = md.getLineNumber();
-        symbolicVariableInfo.returnType = md.getReturnTypeName();
-    }
     @Override
     public void instructionExecuted(VM vm, ThreadInfo currentThread, Instruction nextInstruction,
             Instruction executedInstruction) {
@@ -246,13 +167,10 @@ public class SymbolicListener extends PropertyListenerAdapter implements Publish
 
             ThreadInfo ti = currentThread;
             Config conf = vm.getConfig();
-            String strInsn = executedInstruction.toString();
 
+            // fill the assumption scope if not filled already
+            oneTimeFillAssumptionScope(ti);
 
-            if(!witnessAssumptionScopeIsFilled){
-                parseAssumptionScope(ti);
-                witnessAssumptionScopeIsFilled = true;
-            }
             if (insn instanceof JVMInvokeInstruction) {
                 JVMInvokeInstruction md = (JVMInvokeInstruction) insn;
                 String methodName = md.getInvokedMethodName();
@@ -262,9 +180,10 @@ public class SymbolicListener extends PropertyListenerAdapter implements Publish
                 ClassInfo ci = mi.getClassInfo();
                 String className = ci.getName();
 
-                if(strInsn.contains("invokestatic") && strInsn.contains("Verifier.nondet")){
-                    interceptSymbolic = true;
-                }
+                // maintain the state of whether we are still trying to intercept creation of symbolic variables
+                // catch the invokestatic.Verifier.nondet~~
+                // and store the line number and type
+                maintainWitnessInterceptionState(executedInstruction);
 
                 StackFrame sf = ti.getTopFrame();
                 String shortName = methodName;
@@ -276,9 +195,7 @@ public class SymbolicListener extends PropertyListenerAdapter implements Publish
                     return;
                 // catch the invokestatic.Verifier.nondet~~
                 // and store the line number and type
-                if(className.contains("Verifier") && methodName.contains("nondet")){
-                    extractSymbolicVariableInfo(md);
-                }
+                // collectVerifierCalss(className, methodName, md);
                 if ((BytecodeUtils.isClassSymbolic(conf, className, mi, methodName))
                         || BytecodeUtils.isMethodSymbolic(conf, mi.getFullName(), numberOfArgs, null)) {
 
@@ -351,16 +268,8 @@ public class SymbolicListener extends PropertyListenerAdapter implements Publish
                     String longName = mi.getLongName();
                     int numberOfArgs = mi.getNumberOfArguments();
 
-                    StackFrame sf = ti.getTopFrame();
-                    Object symbolicVar = sf.getOperandAttr();
-
-                    if(interceptSymbolic && strInsn.contains("nativereturn") && strInsn.contains("makeSymbolic")){
-                        symbolicVariableInfo.varName = symbolicVar.toString();
-                        symbolicVariableInfoList.add(symbolicVariableInfo);
-
-                        // Resetting interceptSymbolic
-                        interceptSymbolic = false;
-                    }
+                    //collect the state of symbolic variables from native return statements, if any
+                    collectSymNativeReturn(insn, ti);
 
                     if (((BytecodeUtils.isClassSymbolic(conf, className, mi, methodName))
                             || BytecodeUtils.isMethodSymbolic(conf, mi.getFullName(), numberOfArgs, null))) {

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/SymbolicListener.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/SymbolicListener.java
@@ -161,6 +161,7 @@ public class SymbolicListener extends PropertyListenerAdapter implements Publish
     @Override
     public void instructionExecuted(VM vm, ThreadInfo currentThread, Instruction nextInstruction,
             Instruction executedInstruction) {
+        collectPgmNameForSymVar(executedInstruction);
 
         if (!vm.getSystemState().isIgnored()) {
             Instruction insn = executedInstruction;

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/string/translate/TranslateToZ3str3.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/string/translate/TranslateToZ3str3.java
@@ -36,6 +36,7 @@ public class TranslateToZ3str3 {
 			System.out.println("Satisfiable: " + o.isSAT());
 			for (String k : o.getModel().keySet()) {
 				System.out.println(k + " => " + o.getModel().get(k));
+//				this replacement needs to be disabled since we want to carry quotation marks when printing witnesses
 //				solution.put(k, o.getModel().get(k).replaceAll("^\"|\"$", ""));
 				solution.put(k, o.getModel().get(k));
 			}

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/string/translate/TranslateToZ3str3.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/string/translate/TranslateToZ3str3.java
@@ -36,7 +36,8 @@ public class TranslateToZ3str3 {
 			System.out.println("Satisfiable: " + o.isSAT());
 			for (String k : o.getModel().keySet()) {
 				System.out.println(k + " => " + o.getModel().get(k));
-				solution.put(k, o.getModel().get(k).replaceAll("^\"|\"$", ""));
+//				solution.put(k, o.getModel().get(k).replaceAll("^\"|\"$", ""));
+				solution.put(k, o.getModel().get(k));
 			}
 			pc.solution = new HashMap<String, String>(solution);
 			System.out.println("*************************************\n");

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/witness/Edge.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/witness/Edge.java
@@ -64,17 +64,17 @@ public class Edge{
         if(symbolicVariableInfoList.get(indexOfEdge).returnType.equals("double") ||
                 symbolicVariableInfoList.get(indexOfEdge).returnType.equals("float")){
             if(symbolicVariableInfoList.get(indexOfEdge).varValue == null) {
-                edgeBuilder.append(String.format("         <data key=\"assumption\">%s == %f</data>\n", symbolicVariableInfoList.get(indexOfEdge).varPgmName, 2.0));
+                edgeBuilder.append(String.format("         <data key=\"assumption\">%s = %f</data>\n", symbolicVariableInfoList.get(indexOfEdge).varPgmName, 2.0));
             }
-            else edgeBuilder.append(String.format("         <data key=\"assumption\">%s == %f</data>\n", symbolicVariableInfoList.get(indexOfEdge).varPgmName, symbolicVariableInfoList.get(indexOfEdge).varValue));
+            else edgeBuilder.append(String.format("         <data key=\"assumption\">%s = %f</data>\n", symbolicVariableInfoList.get(indexOfEdge).varPgmName, symbolicVariableInfoList.get(indexOfEdge).varValue));
         }
 
         else if(symbolicVariableInfoList.get(indexOfEdge).returnType.equals("boolean")){
-            if(symbolicVariableInfoList.get(indexOfEdge).varValue == null) edgeBuilder.append(String.format("         <data key=\"assumption\">%s == %b</data>\n", symbolicVariableInfoList.get(indexOfEdge).varPgmName, true));
+            if(symbolicVariableInfoList.get(indexOfEdge).varValue == null) edgeBuilder.append(String.format("         <data key=\"assumption\">%s = %b</data>\n", symbolicVariableInfoList.get(indexOfEdge).varPgmName, true));
             else if(symbolicVariableInfoList.get(indexOfEdge).varValue instanceof String) {
-                edgeBuilder.append(String.format("         <data key=\"assumption\">%s == %b</data>\n", symbolicVariableInfoList.get(indexOfEdge).varPgmName, Boolean.valueOf(
+                edgeBuilder.append(String.format("         <data key=\"assumption\">%s = %b</data>\n", symbolicVariableInfoList.get(indexOfEdge).varPgmName, Boolean.valueOf(
                         (String) symbolicVariableInfoList.get(indexOfEdge).varValue)));
-            } else edgeBuilder.append(String.format("         <data key=\"assumption\">%s == %b</data>\n", symbolicVariableInfoList.get(indexOfEdge).varPgmName, symbolicVariableInfoList.get(indexOfEdge).varValue));
+            } else edgeBuilder.append(String.format("         <data key=\"assumption\">%s = %b</data>\n", symbolicVariableInfoList.get(indexOfEdge).varPgmName, symbolicVariableInfoList.get(indexOfEdge).varValue));
         }
 
         else if(symbolicVariableInfoList.get(indexOfEdge).returnType.equals("java.lang.String")){
@@ -83,8 +83,8 @@ public class Edge{
                 else edgeBuilder.append(String.format("         <data key=\"assumption\">%s.equals(\"%s\")</data>\n", symbolicVariableInfoList.get(indexOfEdge).varPgmName,symbolicVariableInfoList.get(indexOfEdge).varValue));
             }
             else{
-                if(symbolicVariableInfoList.get(indexOfEdge).varValue == null) edgeBuilder.append(String.format("         <data key=\"assumption\">%s==%s</data>\n", symbolicVariableInfoList.get(indexOfEdge).varPgmName, "\"\""));
-                else edgeBuilder.append(String.format("         <data key=\"assumption\">%s==%s</data>\n", symbolicVariableInfoList.get(indexOfEdge).varPgmName, symbolicVariableInfoList.get(indexOfEdge).varValue));
+                if(symbolicVariableInfoList.get(indexOfEdge).varValue == null) edgeBuilder.append(String.format("         <data key=\"assumption\">%s = %s</data>\n", symbolicVariableInfoList.get(indexOfEdge).varPgmName, "\"\""));
+                else edgeBuilder.append(String.format("         <data key=\"assumption\">%s = %s</data>\n", symbolicVariableInfoList.get(indexOfEdge).varPgmName, symbolicVariableInfoList.get(indexOfEdge).varValue));
             }
         }
 
@@ -92,8 +92,8 @@ public class Edge{
             // Here, the type of symbolic variable should be integer or char.
             assert(symbolicVariableInfoList.get(indexOfEdge).returnType.equals("int") ||
                     symbolicVariableInfoList.get(indexOfEdge).returnType.equals("char"));
-            if(symbolicVariableInfoList.get(indexOfEdge).varValue == null) edgeBuilder.append(String.format("         <data key=\"assumption\">%s == %d</data>\n", symbolicVariableInfoList.get(indexOfEdge).varPgmName, 4));
-            else edgeBuilder.append(String.format("         <data key=\"assumption\">%s == %s</data>\n", symbolicVariableInfoList.get(indexOfEdge).varPgmName, symbolicVariableInfoList.get(indexOfEdge).varValue));
+            if(symbolicVariableInfoList.get(indexOfEdge).varValue == null) edgeBuilder.append(String.format("         <data key=\"assumption\">%s = %d</data>\n", symbolicVariableInfoList.get(indexOfEdge).varPgmName, 4));
+            else edgeBuilder.append(String.format("         <data key=\"assumption\">%s = %s</data>\n", symbolicVariableInfoList.get(indexOfEdge).varPgmName, symbolicVariableInfoList.get(indexOfEdge).varValue));
         }
 
         edgeBuilder.append(String.format("         <data key=\"assumption.scope\">java::L%s;</data>\n", assumptionScope));

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/witness/Edge.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/witness/Edge.java
@@ -64,24 +64,24 @@ public class Edge{
         if(symbolicVariableInfoList.get(indexOfEdge).returnType.equals("double") ||
                 symbolicVariableInfoList.get(indexOfEdge).returnType.equals("float")){
             if(symbolicVariableInfoList.get(indexOfEdge).varValue == null) {
-                edgeBuilder.append(String.format("         <data key=\"assumption\">%s == %f</data>\n", symbolicVariableInfoList.get(indexOfEdge).varName, 2.0));
+                edgeBuilder.append(String.format("         <data key=\"assumption\">%s == %f</data>\n", symbolicVariableInfoList.get(indexOfEdge).varPgmName, 2.0));
             }
-            else edgeBuilder.append(String.format("         <data key=\"assumption\">%s == %f</data>\n", symbolicVariableInfoList.get(indexOfEdge).varName, symbolicVariableInfoList.get(indexOfEdge).varValue));
+            else edgeBuilder.append(String.format("         <data key=\"assumption\">%s == %f</data>\n", symbolicVariableInfoList.get(indexOfEdge).varPgmName, symbolicVariableInfoList.get(indexOfEdge).varValue));
         }
 
         else if(symbolicVariableInfoList.get(indexOfEdge).returnType.equals("boolean")){
-            if(symbolicVariableInfoList.get(indexOfEdge).varValue == null) edgeBuilder.append(String.format("         <data key=\"assumption\">%s == %b</data>\n", symbolicVariableInfoList.get(indexOfEdge).varName, true));
-            else edgeBuilder.append(String.format("         <data key=\"assumption\">%s == %b</data>\n", symbolicVariableInfoList.get(indexOfEdge).varName, symbolicVariableInfoList.get(indexOfEdge).varValue));
+            if(symbolicVariableInfoList.get(indexOfEdge).varValue == null) edgeBuilder.append(String.format("         <data key=\"assumption\">%s == %b</data>\n", symbolicVariableInfoList.get(indexOfEdge).varPgmName, true));
+            else edgeBuilder.append(String.format("         <data key=\"assumption\">%s == %b</data>\n", symbolicVariableInfoList.get(indexOfEdge).varPgmName, symbolicVariableInfoList.get(indexOfEdge).varValue));
         }
 
         else if(symbolicVariableInfoList.get(indexOfEdge).returnType.equals("java.lang.String")){
             if(allowMethodInvocation){
-                if(symbolicVariableInfoList.get(indexOfEdge).varValue == null) edgeBuilder.append(String.format("         <data key=\"assumption\">%s.equals(%s)</data>\n", symbolicVariableInfoList.get(indexOfEdge).varName, "\"\""));
-                else edgeBuilder.append(String.format("         <data key=\"assumption\">%s.equals(%s)</data>\n", symbolicVariableInfoList.get(indexOfEdge).varName,symbolicVariableInfoList.get(indexOfEdge).varValue));
+                if(symbolicVariableInfoList.get(indexOfEdge).varValue == null) edgeBuilder.append(String.format("         <data key=\"assumption\">%s.equals(%s)</data>\n", symbolicVariableInfoList.get(indexOfEdge).varPgmName, "\"\""));
+                else edgeBuilder.append(String.format("         <data key=\"assumption\">%s.equals(\"%s\")</data>\n", symbolicVariableInfoList.get(indexOfEdge).varPgmName,symbolicVariableInfoList.get(indexOfEdge).varValue));
             }
             else{
-                if(symbolicVariableInfoList.get(indexOfEdge).varValue == null) edgeBuilder.append(String.format("         <data key=\"assumption\">%s==%s</data>\n", symbolicVariableInfoList.get(indexOfEdge).varName, "\"\""));
-                else edgeBuilder.append(String.format("         <data key=\"assumption\">%s==%s</data>\n", symbolicVariableInfoList.get(indexOfEdge).varName, symbolicVariableInfoList.get(indexOfEdge).varValue));
+                if(symbolicVariableInfoList.get(indexOfEdge).varValue == null) edgeBuilder.append(String.format("         <data key=\"assumption\">%s==%s</data>\n", symbolicVariableInfoList.get(indexOfEdge).varPgmName, "\"\""));
+                else edgeBuilder.append(String.format("         <data key=\"assumption\">%s==%s</data>\n", symbolicVariableInfoList.get(indexOfEdge).varPgmName, symbolicVariableInfoList.get(indexOfEdge).varValue));
             }
         }
 
@@ -89,8 +89,8 @@ public class Edge{
             // Here, the type of symbolic variable should be integer or char.
             assert(symbolicVariableInfoList.get(indexOfEdge).returnType.equals("int") ||
                     symbolicVariableInfoList.get(indexOfEdge).returnType.equals("char"));
-            if(symbolicVariableInfoList.get(indexOfEdge).varValue == null) edgeBuilder.append(String.format("         <data key=\"assumption\">%s == %d</data>\n", symbolicVariableInfoList.get(indexOfEdge).varName, 4));
-            else edgeBuilder.append(String.format("         <data key=\"assumption\">%s == %d</data>\n", symbolicVariableInfoList.get(indexOfEdge).varName, symbolicVariableInfoList.get(indexOfEdge).varValue));
+            if(symbolicVariableInfoList.get(indexOfEdge).varValue == null) edgeBuilder.append(String.format("         <data key=\"assumption\">%s == %d</data>\n", symbolicVariableInfoList.get(indexOfEdge).varPgmName, 4));
+            else edgeBuilder.append(String.format("         <data key=\"assumption\">%s == %d</data>\n", symbolicVariableInfoList.get(indexOfEdge).varPgmName, symbolicVariableInfoList.get(indexOfEdge).varValue));
         }
 
         edgeBuilder.append(String.format("         <data key=\"assumption.scope\">java::L%s;</data>\n", assumptionScope));

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/witness/Edge.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/witness/Edge.java
@@ -71,7 +71,10 @@ public class Edge{
 
         else if(symbolicVariableInfoList.get(indexOfEdge).returnType.equals("boolean")){
             if(symbolicVariableInfoList.get(indexOfEdge).varValue == null) edgeBuilder.append(String.format("         <data key=\"assumption\">%s == %b</data>\n", symbolicVariableInfoList.get(indexOfEdge).varPgmName, true));
-            else edgeBuilder.append(String.format("         <data key=\"assumption\">%s == %b</data>\n", symbolicVariableInfoList.get(indexOfEdge).varPgmName, symbolicVariableInfoList.get(indexOfEdge).varValue));
+            else if(symbolicVariableInfoList.get(indexOfEdge).varValue instanceof String) {
+                edgeBuilder.append(String.format("         <data key=\"assumption\">%s == %b</data>\n", symbolicVariableInfoList.get(indexOfEdge).varPgmName, Boolean.valueOf(
+                        (String) symbolicVariableInfoList.get(indexOfEdge).varValue)));
+            } else edgeBuilder.append(String.format("         <data key=\"assumption\">%s == %b</data>\n", symbolicVariableInfoList.get(indexOfEdge).varPgmName, symbolicVariableInfoList.get(indexOfEdge).varValue));
         }
 
         else if(symbolicVariableInfoList.get(indexOfEdge).returnType.equals("java.lang.String")){
@@ -90,7 +93,7 @@ public class Edge{
             assert(symbolicVariableInfoList.get(indexOfEdge).returnType.equals("int") ||
                     symbolicVariableInfoList.get(indexOfEdge).returnType.equals("char"));
             if(symbolicVariableInfoList.get(indexOfEdge).varValue == null) edgeBuilder.append(String.format("         <data key=\"assumption\">%s == %d</data>\n", symbolicVariableInfoList.get(indexOfEdge).varPgmName, 4));
-            else edgeBuilder.append(String.format("         <data key=\"assumption\">%s == %d</data>\n", symbolicVariableInfoList.get(indexOfEdge).varPgmName, symbolicVariableInfoList.get(indexOfEdge).varValue));
+            else edgeBuilder.append(String.format("         <data key=\"assumption\">%s == %s</data>\n", symbolicVariableInfoList.get(indexOfEdge).varPgmName, symbolicVariableInfoList.get(indexOfEdge).varValue));
         }
 
         edgeBuilder.append(String.format("         <data key=\"assumption.scope\">java::L%s;</data>\n", assumptionScope));

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/witness/Edge.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/witness/Edge.java
@@ -80,7 +80,7 @@ public class Edge{
         else if(symbolicVariableInfoList.get(indexOfEdge).returnType.equals("java.lang.String")){
             if(allowMethodInvocation){
                 if(symbolicVariableInfoList.get(indexOfEdge).varValue == null) edgeBuilder.append(String.format("         <data key=\"assumption\">%s.equals(%s)</data>\n", symbolicVariableInfoList.get(indexOfEdge).varPgmName, "\"\""));
-                else edgeBuilder.append(String.format("         <data key=\"assumption\">%s.equals(\"%s\")</data>\n", symbolicVariableInfoList.get(indexOfEdge).varPgmName,symbolicVariableInfoList.get(indexOfEdge).varValue));
+                else edgeBuilder.append(String.format("         <data key=\"assumption\">%s.equals(%s)</data>\n", symbolicVariableInfoList.get(indexOfEdge).varPgmName,symbolicVariableInfoList.get(indexOfEdge).varValue));
             }
             else{
                 if(symbolicVariableInfoList.get(indexOfEdge).varValue == null) edgeBuilder.append(String.format("         <data key=\"assumption\">%s = %s</data>\n", symbolicVariableInfoList.get(indexOfEdge).varPgmName, "\"\""));

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/witness/Edge.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/witness/Edge.java
@@ -89,6 +89,9 @@ public class Edge{
         }
 
         else{
+            //TODO: be conservative and not generate a witness if we cannot find a solution for the symbolic variable
+            // , i.e., do not print default value.
+
             // Here, the type of symbolic variable should be integer or char.
             assert(symbolicVariableInfoList.get(indexOfEdge).returnType.equals("int") ||
                     symbolicVariableInfoList.get(indexOfEdge).returnType.equals("char"));

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/witness/PathConditionParser.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/witness/PathConditionParser.java
@@ -72,7 +72,8 @@ public class PathConditionParser{
             String solution = pc.spc.solution.get(symInfo.varSymName);
             if(solution != null) {
                 if (symInfo.returnType.contains("String")) {
-                    symInfo.varValue = solution;
+                    // escaping backslahses so that they appear in the witness string
+                    symInfo.varValue = solution.replaceAll("\\\\", "\\\\\\\\");
                 } else if (symInfo.returnType.contains("int")) {
                     symInfo.varValue = solution;
                 } else if (symInfo.returnType.equals("boolean")) {

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/witness/PathConditionParser.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/witness/PathConditionParser.java
@@ -73,13 +73,10 @@ public class PathConditionParser{
             if(solution != null) {
                 if (symInfo.returnType.contains("String")) {
                     symInfo.varValue = solution;
-                    break;
                 } else if (symInfo.returnType.contains("int")) {
                     symInfo.varValue = solution;
-                    break;
                 } else if (symInfo.returnType.equals("boolean")) {
                     symInfo.varValue = Integer.parseInt(solution) == 0 ? "false" : "true";
-                    break;
                 }
             }
         }

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/witness/PathConditionParser.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/witness/PathConditionParser.java
@@ -61,12 +61,16 @@ public class PathConditionParser{
             }
         }
 
-        for(SymbolicVariableInfo symInfo: symbolicVariableInfoList){
+        for(SymbolicVariableInfo symInfo: symbolicVariableInfoList) {
             if (symInfo.returnType.contains("String")) {
                 symInfo.varValue = pc.spc.solution.get(symInfo.varSymName);
                 break;
             }
 
+            if (symInfo.returnType.equals("boolean")) {
+                symInfo.varValue = Integer.parseInt(pc.spc.solution.get(symInfo.varSymName)) < 0 ? "false" : "true";
+                break;
+            }
         }
 
     }

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/witness/PathConditionParser.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/witness/PathConditionParser.java
@@ -61,15 +61,26 @@ public class PathConditionParser{
             }
         }
 
-        for(SymbolicVariableInfo symInfo: symbolicVariableInfoList) {
-            if (symInfo.returnType.contains("String")) {
-                symInfo.varValue = pc.spc.solution.get(symInfo.varSymName);
-                break;
-            }
+        /**
+         * Attempting to use the string PathCondition to find the solutions for the symbolic variables.
+         * This should be cleaner if we have a consistent way of have a path condition that is joint
+         * between string and numeric, and also, if we have a uniform way of populating an intermediate
+         * datastructure that hold the model of the sat query.
+         */
 
-            if (symInfo.returnType.equals("boolean")) {
-                symInfo.varValue = Integer.parseInt(pc.spc.solution.get(symInfo.varSymName)) < 0 ? "false" : "true";
-                break;
+        for(SymbolicVariableInfo symInfo: symbolicVariableInfoList) {
+            String solution = pc.spc.solution.get(symInfo.varSymName);
+            if(solution != null) {
+                if (symInfo.returnType.contains("String")) {
+                    symInfo.varValue = solution;
+                    break;
+                } else if (symInfo.returnType.contains("int")) {
+                    symInfo.varValue = solution;
+                    break;
+                } else if (symInfo.returnType.equals("boolean")) {
+                    symInfo.varValue = Integer.parseInt(solution) == 0 ? "false" : "true";
+                    break;
+                }
             }
         }
 

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/witness/PathConditionParser.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/witness/PathConditionParser.java
@@ -5,6 +5,8 @@
 package gov.nasa.jpf.symbc.witness;
 
 
+import gov.nasa.jpf.symbc.numeric.PathCondition;
+
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -12,10 +14,12 @@ import java.util.regex.Pattern;
 public class PathConditionParser{
     /**
      * It parses a value of symbolic variable from PathCondition, and match it to corresponding variable
-     * @param strPathCondition is a String type PathCondition
+     * @param pc is PathCondition
      * @param symbolicVariableInfoList is a list that contains the information of symbolic variables
      */
-    public void parseSymVar(String strPathCondition, List<SymbolicVariableInfo> symbolicVariableInfoList){
+    public void parseSymVar(PathCondition pc, List<SymbolicVariableInfo> symbolicVariableInfoList){
+        String strPathCondition = pc.toString();
+
         // Extract variable name and value
         Pattern pattern = Pattern.compile("(\\w+)\\[(-?\\d+(\\.\\d+)?([eE][-+]?\\d+)?)\\]");
         Matcher matcher = pattern.matcher(strPathCondition);
@@ -31,18 +35,8 @@ public class PathConditionParser{
             if (pcVariableName.contains("double") || pcVariableName.contains("float") || pcVariableName.contains("REAL")) {
                 double value = Double.parseDouble(pcVariableValue); // 실수로 파싱
                 for(int i=0; i<symbolicVariableInfoList.size(); i++){
-                    if(symbolicVariableInfoList.get(i).varName.equals(pcVariableName)){
+                    if(symbolicVariableInfoList.get(i).varSymName.equals(pcVariableName)){
                         symbolicVariableInfoList.get(i).varValue = value;
-                        break;
-                    }
-                }
-
-            }
-            // For String type
-            else if (pcVariableName.contains("string")) {
-                for (int i = 0; i < symbolicVariableInfoList.size(); i++) {
-                    if (symbolicVariableInfoList.get(i).varName.equals(pcVariableName)) {
-                        symbolicVariableInfoList.get(i).varValue = pcVariableValue;
                         break;
                     }
                 }
@@ -52,7 +46,7 @@ public class PathConditionParser{
             else {
                 int value = Integer.parseInt(pcVariableValue);
                 for(int i=0; i<symbolicVariableInfoList.size(); i++){
-                    if(symbolicVariableInfoList.get(i).varName.equals(pcVariableName)){
+                    if(symbolicVariableInfoList.get(i).varSymName.equals(pcVariableName)){
                         // special case for boolean type
                         if(symbolicVariableInfoList.get(i).returnType.equals("boolean")){
                             if(value == 1) symbolicVariableInfoList.get(i).varValue = true;
@@ -65,6 +59,14 @@ public class PathConditionParser{
                 }
 
             }
+        }
+
+        for(SymbolicVariableInfo symInfo: symbolicVariableInfoList){
+            if (symInfo.returnType.contains("String")) {
+                symInfo.varValue = pc.spc.solution.get(symInfo.varSymName);
+                break;
+            }
+
         }
 
     }

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/witness/SymbolicVariableInfo.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/witness/SymbolicVariableInfo.java
@@ -13,7 +13,9 @@ public class SymbolicVariableInfo{
         public int lineNumber;
         public String returnType;
 
-        public String varName;
+        public String varSymName;
+
+        public String varPgmName;
 
         public Object varValue = null;
 
@@ -22,7 +24,8 @@ public class SymbolicVariableInfo{
         public SymbolicVariableInfo(SymbolicVariableInfo copy) {
                 this.lineNumber = copy.lineNumber;
                 this.returnType = copy.returnType;
-                this.varName = copy.varName;
+                this.varSymName = copy.varSymName;
+                this.varPgmName = copy.varPgmName;
                 this.varValue = copy.varValue;
         }
 

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/witness/SymbolicVariableInfo.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/witness/SymbolicVariableInfo.java
@@ -9,6 +9,8 @@
 package gov.nasa.jpf.symbc.witness;
 
 
+import choco.cp.solver.constraints.global.geost.geometricPrim.Obj;
+
 public class SymbolicVariableInfo{
         public int lineNumber;
         public String returnType;
@@ -27,6 +29,23 @@ public class SymbolicVariableInfo{
                 this.varSymName = copy.varSymName;
                 this.varPgmName = copy.varPgmName;
                 this.varValue = copy.varValue;
+        }
+
+        @Override
+        public String toString() {
+                return varPgmName + "_" + varSymName + "_" + lineNumber;
+        }
+
+        @Override
+        public int hashCode() {
+                return this.toString().hashCode();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+                if (o instanceof SymbolicVariableInfo)
+                        return this.toString().equals(o.toString());
+                return false;
         }
 
 }

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/witness/SymbolicVariableInfo.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/witness/SymbolicVariableInfo.java
@@ -19,6 +19,13 @@ public class SymbolicVariableInfo{
 
         public SymbolicVariableInfo() {};
 
+        public SymbolicVariableInfo(SymbolicVariableInfo copy) {
+                this.lineNumber = copy.lineNumber;
+                this.returnType = copy.returnType;
+                this.varName = copy.varName;
+                this.varValue = copy.varValue;
+        }
+
 }
 
 

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/witness/WitnessSymbolicState.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/witness/WitnessSymbolicState.java
@@ -44,6 +44,11 @@ public class WitnessSymbolicState {
         Object symbolicVar = sf.getOperandAttr();
         if(interceptSymbolic && strIns.contains("nativereturn") && strIns.contains("makeSymbolic")) {
             symbolicVariableInfo.varSymName = symbolicVar.toString();
+            if(symbolicVariableInfo.varPgmName == null) {
+                // case where we couldn't find the program name of a variable, as in the case where the verifier invocation was within and expression,
+                // for example like an arrayIndex
+                symbolicVariableInfo.varPgmName = symbolicVariableInfo.varSymName;
+            }
             if(!symVarInfoList.contains(symbolicVariableInfo)) {
                 // Copy current symbolic variable details into a new object
                 // so further changes to symbolicVariableInfo won't affect the stored entry
@@ -86,7 +91,11 @@ public class WitnessSymbolicState {
     public static void collectPgmNameForSymVar(Instruction instruction) {
         String strInst = instruction.toString();
         if (strInst.contains("invokestatic") && strInst.contains("Verifier.nondet")) {
-            int symVarStackSlot = findStackSlot(instruction);
+            Integer symVarStackSlot = findStackSlot(instruction);
+            if (symVarStackSlot == null) {
+                // we failed to find a stackslot, it could just be a temp variable, we just return.
+                return;
+            }
             LocalVarInfo[] methodLocalVars = instruction.getMethodInfo().getLocalVars();
             for (int i = 0; i < methodLocalVars.length; i++) {
                 if(methodLocalVars[i].getSlotIndex() == symVarStackSlot) {
@@ -102,16 +111,20 @@ public class WitnessSymbolicState {
      *
      * @return
      */
-    static int findStackSlot(Instruction instruction) {
+    static Integer findStackSlot(Instruction instruction) {
         Instruction[] instructions = instruction.getMethodInfo().getInstructions();
         int pgmCounter = instruction.getInstructionIndex() + 1;
         Instruction nextInstruction = instructions[pgmCounter];
-        while (!nextInstruction.toString().contains("store")) {
-            pgmCounter++;
-            nextInstruction = instructions[pgmCounter];
-        }
+        // we are assuming here that the next instruction would be the store of the verifier invocation, if this is not the case, then the invocation of the verifier must have occurred as a subexpression,
+        // in which case, we cannot tie it with a slot, or a particular program name. So we return, and give the program name the same name as the symbolic name.
+//        while (!nextInstruction.toString().contains("store")) {
+//            pgmCounter++;
+//            nextInstruction = instructions[pgmCounter];
+//        }
+        if(!nextInstruction.toString().contains("store"))
+            return null;
         int storeStackSlot = Integer.parseInt(
-                nextInstruction.toString().substring(nextInstruction.toString().indexOf('_') + 1)
+                nextInstruction.toString().substring(nextInstruction.toString().indexOf("store") + 6)
         );
         return storeStackSlot;
     }

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/witness/WitnessSymbolicState.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/witness/WitnessSymbolicState.java
@@ -56,7 +56,7 @@ public class WitnessSymbolicState {
     // catch the invokestatic.Verifier.nondet~~
     // and store the line number and type
     public static void collectVerifierCalls(String className, String methodName, JVMInvokeInstruction md) {
-        if(className.contains("Verifier") && methodName.contains("nondet")) {
+        if (className.contains("Verifier") && methodName.contains("nondet")) {
             extractSymbolicVariableInfo(md);
         }
     }
@@ -76,7 +76,7 @@ public class WitnessSymbolicState {
     // and store the line number and type
     public static void maintainWitnessInterceptionState(Instruction instruction) {
         String strInst = instruction.toString();
-        if(strInst.contains("invokestatic") && strInst.contains("Verifier.nondet")) {
+        if (strInst.contains("invokestatic") && strInst.contains("Verifier.nondet")) {
             JVMInvokeInstruction md = (JVMInvokeInstruction) instruction;
             extractSymbolicVariableInfo(md);
             interceptSymbolic = true;
@@ -86,19 +86,34 @@ public class WitnessSymbolicState {
     public static void collectPgmNameForSymVar(Instruction instruction) {
         String strInst = instruction.toString();
         if (strInst.contains("invokestatic") && strInst.contains("Verifier.nondet")) {
-            int currPgmCounter = instruction.getInstructionIndex();
-            Instruction nextInstruction = instruction.getMethodInfo().getInstructions()[currPgmCounter + 1];
-            int symVarStackSlot = Integer.parseInt(
-                    nextInstruction.toString().substring(nextInstruction.toString().indexOf('_') + 1)
-            );
+            int symVarStackSlot = findStackSlot(instruction);
             LocalVarInfo[] methodLocalVars = instruction.getMethodInfo().getLocalVars();
-            for(int i=0; i<methodLocalVars.length; i++) {
-                if(methodLocalVars[i].getSlotIndex()==symVarStackSlot) {
+            for (int i = 0; i < methodLocalVars.length; i++) {
+                if(methodLocalVars[i].getSlotIndex() == symVarStackSlot) {
                     symbolicVariableInfo.varPgmName = methodLocalVars[i].getName();
                     return;
                 }
             }
         }
+    }
+
+    /**
+     * finds the nearest store instruction forward, and return its stack slot.
+     *
+     * @return
+     */
+    static int findStackSlot(Instruction instruction) {
+        Instruction[] instructions = instruction.getMethodInfo().getInstructions();
+        int pgmCounter = instruction.getInstructionIndex() + 1;
+        Instruction nextInstruction = instructions[pgmCounter];
+        while (!nextInstruction.toString().contains("store")) {
+            pgmCounter++;
+            nextInstruction = instructions[pgmCounter];
+        }
+        int storeStackSlot = Integer.parseInt(
+                nextInstruction.toString().substring(nextInstruction.toString().indexOf('_') + 1)
+        );
+        return storeStackSlot;
     }
 
     /**

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/witness/WitnessSymbolicState.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/witness/WitnessSymbolicState.java
@@ -44,9 +44,11 @@ public class WitnessSymbolicState {
         Object symbolicVar = sf.getOperandAttr();
         if(interceptSymbolic && strIns.contains("nativereturn") && strIns.contains("makeSymbolic")) {
             symbolicVariableInfo.varSymName = symbolicVar.toString();
-            // Copy current symbolic variable details into a new object
-            // so further changes to symbolicVariableInfo won't affect the stored entry
-            symVarInfoList.add(new SymbolicVariableInfo(symbolicVariableInfo));
+            if(!symVarInfoList.contains(symbolicVariableInfo)) {
+                // Copy current symbolic variable details into a new object
+                // so further changes to symbolicVariableInfo won't affect the stored entry
+                symVarInfoList.add(new SymbolicVariableInfo(symbolicVariableInfo));
+            }
             interceptSymbolic = false;
         }
     }

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/witness/WitnessSymbolicState.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/witness/WitnessSymbolicState.java
@@ -3,10 +3,8 @@ package gov.nasa.jpf.symbc.witness;
 import gov.nasa.jpf.jvm.bytecode.JVMInvokeInstruction;
 import gov.nasa.jpf.symbc.SymbolicListener;
 import gov.nasa.jpf.symbc.numeric.PathCondition;
-import gov.nasa.jpf.vm.ApplicationContext;
-import gov.nasa.jpf.vm.Instruction;
-import gov.nasa.jpf.vm.StackFrame;
-import gov.nasa.jpf.vm.ThreadInfo;
+import gov.nasa.jpf.vm.LocalVarInfo;
+import gov.nasa.jpf.vm.*;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -45,7 +43,7 @@ public class WitnessSymbolicState {
         StackFrame sf = ti.getTopFrame();
         Object symbolicVar = sf.getOperandAttr();
         if(interceptSymbolic && strIns.contains("nativereturn") && strIns.contains("makeSymbolic")) {
-            symbolicVariableInfo.varName = symbolicVar.toString();
+            symbolicVariableInfo.varSymName = symbolicVar.toString();
             // Copy current symbolic variable details into a new object
             // so further changes to symbolicVariableInfo won't affect the stored entry
             symVarInfoList.add(new SymbolicVariableInfo(symbolicVariableInfo));
@@ -80,6 +78,24 @@ public class WitnessSymbolicState {
             JVMInvokeInstruction md = (JVMInvokeInstruction) instruction;
             extractSymbolicVariableInfo(md);
             interceptSymbolic = true;
+        }
+    }
+
+    public static void collectPgmNameForSymVar(Instruction instruction) {
+        String strInst = instruction.toString();
+        if (strInst.contains("invokestatic") && strInst.contains("Verifier.nondet")) {
+            int currPgmCounter = instruction.getInstructionIndex();
+            Instruction nextInstruction = instruction.getMethodInfo().getInstructions()[currPgmCounter + 1];
+            int symVarStackSlot = Integer.parseInt(
+                    nextInstruction.toString().substring(nextInstruction.toString().indexOf('_') + 1)
+            );
+            LocalVarInfo[] methodLocalVars = instruction.getMethodInfo().getLocalVars();
+            for(int i=0; i<methodLocalVars.length; i++) {
+                if(methodLocalVars[i].getSlotIndex()==symVarStackSlot) {
+                    symbolicVariableInfo.varPgmName = methodLocalVars[i].getName();
+                    return;
+                }
+            }
         }
     }
 
@@ -122,11 +138,10 @@ public class WitnessSymbolicState {
 
     //  populates the GraphML with the witness information
     public static void populateWitnessGraph(PathCondition pc) {
-        String strPathCondition = pc.toString();
         List<Node> nodeList = new ArrayList<>();
         List<Edge> edgeList = new ArrayList<>();
         PathConditionParser parser = new PathConditionParser();
-        parser.parseSymVar(strPathCondition, symVarInfoList);
+        parser.parseSymVar(pc, symVarInfoList);
         for (int i = 0; i < symVarInfoList.size(); i++) {
             Node node = new Node(symVarInfoList.size(), i, false);
             nodeList.add(node);

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/witness/WitnessSymbolicState.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/witness/WitnessSymbolicState.java
@@ -122,7 +122,18 @@ public class WitnessSymbolicState {
 //            pgmCounter++;
 //            nextInstruction = instructions[pgmCounter];
 //        }
-        if(!nextInstruction.toString().contains("store"))
+        String nextInstructionString = nextInstruction.toString();
+        // skip array stores
+        boolean isArrayStore = nextInstructionString.equals("aastore") ||
+                nextInstructionString.equals("iastore") ||
+                nextInstructionString.equals("lastore") ||
+                nextInstructionString.equals("fastore") ||
+                nextInstructionString.equals("dastore") ||
+                nextInstructionString.equals("bastore") ||
+                nextInstructionString.equals("castore") ||
+                nextInstructionString.equals("sastore");
+
+        if(!nextInstructionString.contains("store") || isArrayStore)
             return null;
         int storeStackSlot = Integer.parseInt(
                 nextInstruction.toString().substring(nextInstruction.toString().indexOf("store") + 6)

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/witness/WitnessSymbolicState.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/witness/WitnessSymbolicState.java
@@ -1,0 +1,153 @@
+package gov.nasa.jpf.symbc.witness;
+
+import gov.nasa.jpf.jvm.bytecode.JVMInvokeInstruction;
+import gov.nasa.jpf.symbc.SymbolicListener;
+import gov.nasa.jpf.symbc.numeric.PathCondition;
+import gov.nasa.jpf.vm.ApplicationContext;
+import gov.nasa.jpf.vm.Instruction;
+import gov.nasa.jpf.vm.StackFrame;
+import gov.nasa.jpf.vm.ThreadInfo;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This class maintains the witness collection state that is invoked by the listener during execution.
+ */
+public class WitnessSymbolicState {
+
+    // Path to the witness template
+    // Assume working directory is SPF
+
+    static String resourcePath = "witness_template/witness_template_minimal.txt";
+
+    // Path to output directory, now it is current directory
+    static String outputFilePath = "witness.graphml";
+
+    // Temporary object to save the information of symbolic variable
+    static SymbolicVariableInfo symbolicVariableInfo = new SymbolicVariableInfo();
+
+    // A list to save line number and return type
+    public static List<SymbolicVariableInfo> symVarInfoList = new ArrayList<>();
+
+    static boolean allowMethodInvocation = true;
+    // A flag to check whether the information of symbolic variable is already parsed or not.
+    static boolean interceptSymbolic = false;
+    static boolean witnessAssumptionScopeIsFilled = false;
+    static String fileName = "";
+    static String assumptionScope = "";
+
+
+    public static void collectSymNativeReturn(Instruction instruction, ThreadInfo ti) {
+        String strIns = instruction.toString();
+        StackFrame sf = ti.getTopFrame();
+        Object symbolicVar = sf.getOperandAttr();
+        if(interceptSymbolic && strIns.contains("nativereturn") && strIns.contains("makeSymbolic")) {
+            symbolicVariableInfo.varName = symbolicVar.toString();
+            // Copy current symbolic variable details into a new object
+            // so further changes to symbolicVariableInfo won't affect the stored entry
+            symVarInfoList.add(new SymbolicVariableInfo(symbolicVariableInfo));
+            interceptSymbolic = false;
+        }
+    }
+
+    // catch the invokestatic.Verifier.nondet~~
+    // and store the line number and type
+    public static void collectVerifierCalls(String className, String methodName, JVMInvokeInstruction md) {
+        if(className.contains("Verifier") && methodName.contains("nondet")) {
+            extractSymbolicVariableInfo(md);
+        }
+    }
+
+    /**
+     * Method that extracts line number and type of symbolic variables
+     *
+     * @param md JVMInvokeInstruction object
+     */
+    public static void extractSymbolicVariableInfo(JVMInvokeInstruction md) {
+        symbolicVariableInfo.lineNumber = md.getLineNumber();
+        symbolicVariableInfo.returnType = md.getReturnTypeName();
+    }
+
+    //maintain the state of whether we are still trying to intercept creation of symbolic variables
+    // catch the invokestatic.Verifier.nondet~~
+    // and store the line number and type
+    public static void maintainWitnessInterceptionState(Instruction instruction) {
+        String strInst = instruction.toString();
+        if(strInst.contains("invokestatic") && strInst.contains("Verifier.nondet")) {
+            JVMInvokeInstruction md = (JVMInvokeInstruction) instruction;
+            extractSymbolicVariableInfo(md);
+            interceptSymbolic = true;
+        }
+    }
+
+    /**
+     * It parses classname and filename to fill the value of assumption.scope at violation witness
+     * Both classname and filename are needed to construct the edge of the witness assumptionScope is
+     * a value of assumption.scope attribute of violation witness fileName is a value of originfile
+     * attribute of violation witness
+     */
+    public static void parseAssumptionScope(ThreadInfo ti) {
+        ApplicationContext app = ti.getApplicationContext();
+        String className = app.getMainClassName();
+        String[] parts = className.split("\\.");
+        fileName = parts[parts.length - 1];
+        assumptionScope = String.join(".", parts);
+    }
+
+    public static void oneTimeFillAssumptionScope(ThreadInfo ti) {
+        if(!witnessAssumptionScopeIsFilled) {
+            parseAssumptionScope(ti);
+            witnessAssumptionScopeIsFilled = true;
+        }
+    }
+
+    public static void createEmptyWitness() {
+        Node nodeForEmptyWitness = new Node(1, 0, true);
+        String strNode = nodeForEmptyWitness.serializeNode();
+        try (InputStream inputStream = SymbolicListener.class.getClassLoader()
+                .getResourceAsStream(resourcePath)) {
+            if (inputStream == null) {
+                throw new IllegalArgumentException("Resource not found : " + resourcePath);
+            }
+            GraphML emptyWitness = new GraphML(inputStream, outputFilePath);
+            String headerForEmptyWitness = emptyWitness.constructHeader();
+            emptyWitness.serializeEmptyWitness(strNode, headerForEmptyWitness);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    //  populates the GraphML with the witness information
+    public static void populateWitnessGraph(PathCondition pc) {
+        String strPathCondition = pc.toString();
+        List<Node> nodeList = new ArrayList<>();
+        List<Edge> edgeList = new ArrayList<>();
+        PathConditionParser parser = new PathConditionParser();
+        parser.parseSymVar(strPathCondition, symVarInfoList);
+        for (int i = 0; i < symVarInfoList.size(); i++) {
+            Node node = new Node(symVarInfoList.size(), i, false);
+            nodeList.add(node);
+            Edge edge = new Edge(i, fileName, symVarInfoList, allowMethodInvocation,
+                    assumptionScope);
+            edgeList.add(edge);
+        }
+        // Add last node that contains violation key
+        nodeList.add(new Node(symVarInfoList.size(), symVarInfoList.size(), false));
+        try (InputStream inputStream = SymbolicListener.class.getClassLoader()
+                .getResourceAsStream(resourcePath)) {
+            if (inputStream == null) {
+                throw new IllegalArgumentException("Resource not found : " + resourcePath);
+            }
+            GraphML graphML = new GraphML(inputStream, outputFilePath);
+            String header = graphML.constructHeader();
+            graphML.serializeWitness(edgeList, nodeList, header);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+    }
+
+}

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/witness/WitnessSymbolicState.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/witness/WitnessSymbolicState.java
@@ -52,7 +52,7 @@ public class WitnessSymbolicState {
             if(!symVarInfoList.contains(symbolicVariableInfo)) {
                 // Copy current symbolic variable details into a new object
                 // so further changes to symbolicVariableInfo won't affect the stored entry
-                symVarInfoList.add(new SymbolicVariableInfo(symbolicVariableInfo));
+                symVarInfoList.add(symbolicVariableInfo);
             }
             interceptSymbolic = false;
         }
@@ -91,6 +91,7 @@ public class WitnessSymbolicState {
     public static void collectPgmNameForSymVar(Instruction instruction) {
         String strInst = instruction.toString();
         if (strInst.contains("invokestatic") && strInst.contains("Verifier.nondet")) {
+            symbolicVariableInfo = new SymbolicVariableInfo();
             Integer symVarStackSlot = findStackSlot(instruction);
             if (symVarStackSlot == null) {
                 // we failed to find a stackslot, it could just be a temp variable, we just return.


### PR DESCRIPTION
Changes from java-ranger :

- Move witness generation from SymbolicListener to WitnessSymbolicState for better separation of concerns.

- Set allowMethodInvocation flag to true during witness generation to avoid string assumption errors from wit4java.

- Extract and populate values of string symbolic variables from StringPathCondition

 - translate the integer boolean variable used in the smt query to the proper true and false value for witness generation

- use '=' instead of '==' in witness assumptions

- collect and use program variable names within the witness

- allow the witness generated to escape backslashes

Other Changes and fixes :

- skip array store instructions in findStackSlot
