### PR TITLE
z3 string support update

### DIFF
--- a/jpf-symbc/src/main/edu/ucsb/cs/vlab/translate/smtlib/StringOrOperation.java
+++ b/jpf-symbc/src/main/edu/ucsb/cs/vlab/translate/smtlib/StringOrOperation.java
@@ -27,6 +27,9 @@ public final class StringOrOperation {
 	public static final StringOrOperation TOLOWERCASE = new StringOrOperation(StringOperator.TOLOWERCASE);
 	public static final StringOrOperation TOUPPERCASE = new StringOrOperation(StringOperator.TOUPPERCASE);
 	public static final StringOrOperation VALUEOF = new StringOrOperation(StringOperator.VALUEOF);
+    public static final StringOrOperation REVERSE = new StringOrOperation(StringOperator.REVERSE);
+    public static final StringOrOperation DELETE = new StringOrOperation(StringOperator.DELETE);
+    public static final StringOrOperation INSERT = new StringOrOperation(StringOperator.INSERT);
 
 	@Override
 	public boolean equals(Object o) {

--- a/jpf-symbc/src/main/edu/ucsb/cs/vlab/translate/smtlib/from/z3str3/Z3Translator.java
+++ b/jpf-symbc/src/main/edu/ucsb/cs/vlab/translate/smtlib/from/z3str3/Z3Translator.java
@@ -152,8 +152,8 @@ class Manager extends TranslationManager {
 			map(StringComparator.NOTEQUALS, "(not (=");
 			map(StringComparator.EQUALSIGNORECASE, "(equalsIgnoreCase");
 			map(StringComparator.NOTEQUALSIGNORECASE, "(not (equalsIgnoreCase");
-			map(StringComparator.EMPTY, "(empty");
-			map(StringComparator.NOTEMPTY, "(not (empty");
+			map(StringComparator.EMPTY, "(= 0 (str.len");
+            map(StringComparator.NOTEMPTY, "(not (= 0 (str.len");
 			map(StringComparator.MATCHES, "(matches");
 			map(StringComparator.NOMATCHES, "(not (matches");
 			map(StringComparator.REGIONMATCHES, "(regionMatches");
@@ -261,9 +261,9 @@ class Manager extends TranslationManager {
 				}
 			});
 
-			map(StringOrOperation.REPLACE, ReplaceTemplate.apply("(str.replace"));
-			map(StringOrOperation.REPLACEALL, ReplaceTemplate.apply("(replaceAll"));
-			map(StringOrOperation.REPLACEFIRST, ReplaceTemplate.apply("(replaceFirst"));
+            map(StringOrOperation.REPLACE, ReplaceTemplate.apply("(str.replace_all"));
+            map(StringOrOperation.REPLACEALL, ReplaceTemplate.apply("(str.replace_all"));
+            map(StringOrOperation.REPLACEFIRST, ReplaceTemplate.apply("(str.replace"));
 
 			map(StringOrOperation.TRIM, (expr) -> {
 				final DerivedStringExpression dse = (DerivedStringExpression) expr;
@@ -277,8 +277,51 @@ class Manager extends TranslationManager {
 				Results.constraints.add("(assert (and (str.in_re " + in_str + " (re.++ ws (str.to_re out_str) ws)) (or (= out_str \"\")(and (str.in_re out_str (re.++ nwc re.all)) (str.in_re out_str (re.++ re.all nwc))))))");
 				return arg;
 			});
-			map(StringOrOperation.TOLOWERCASE, RightTemplate.apply("(toLowerCase"));
-			map(StringOrOperation.TOUPPERCASE, RightTemplate.apply("(toUpperCase"));
+
+			map(StringOrOperation.TOLOWERCASE, (expr) -> {
+                final DerivedStringExpression dse = (DerivedStringExpression) expr;
+                final String in_str = manager.strExpr.collect(dse.right);
+                String arg = "out_str";
+                Results.stringVariables.add("out_str");
+                Results.constraints.add(
+                    "(define-fun-rec toLower ((x String) (y String)) Bool " +
+                      "(or (and (= x \"\") (= y \"\")) " +
+                        "(and (not (= x \"\")) (not (= y \"\")) " +
+                          "(let ((x_head (str.at x 0)) " +
+                                "(y_head (str.at y 0)) " +
+                                "(x_tail (str.substr x 1 (- (str.len x) 1))) " +
+                                "(y_tail (str.substr y 1 (- (str.len y) 1)))) " +
+                            "(and (= (str.to_code y_head) " +
+                                  "(ite (and (<= 65 (str.to_code x_head)) (<= (str.to_code x_head)                 90)) " +
+                                    "(+ (str.to_code x_head) 32) " +
+                                    "(str.to_code x_head))) " +
+                                 "(toLower x_tail y_tail))))))" +
+                    "\n(assert (toLower " + in_str + " out_str))"
+                );
+                return arg;
+            });
+            map(StringOrOperation.TOUPPERCASE, (expr) -> {
+                final DerivedStringExpression dse = (DerivedStringExpression) expr;
+                final String in_str = manager.strExpr.collect(dse.right);
+                String arg = "out_str";
+                Results.stringVariables.add("out_str");
+                Results.constraints.add(
+                    "(define-fun-rec toUpper ((x String) (y String)) Bool " +
+                      "(or (and (= x \"\") (= y \"\")) " +
+                        "(and (not (= x \"\")) (not (= y \"\")) " +
+                          "(let ((x_head (str.at x 0)) " +
+                                "(y_head (str.at y 0)) " +
+                                "(x_tail (str.substr x 1 (- (str.len x) 1))) " +
+                                "(y_tail (str.substr y 1 (- (str.len y) 1)))) " +
+                            "(and (= (str.to_code y_head) " +
+                                  "(ite (and (<= 97 (str.to_code x_head)) (<= (str.to_code x_head) 122)) " +
+                                    "(- (str.to_code x_head) 32) " +
+                                    "(str.to_code x_head))) " +
+                                 "(toUpper x_tail y_tail))))))" +
+                    "\n(assert (toUpper " + in_str + " out_str))"
+                );
+                return arg;
+            });
 
 			map(StringOrOperation.VALUEOF, (expr) -> {
 				String arg = null;
@@ -314,6 +357,42 @@ class Manager extends TranslationManager {
 				} catch (NumberFormatException e) {
 					return arg;
 				}
+			});
+
+			map(StringOrOperation.DELETE, (expr) -> {
+				final DerivedStringExpression dse = (DerivedStringExpression) expr;
+				final String in_str = manager.strExpr.collect((StringExpression) dse.oprlist[0]);
+				final String arg1 = manager.numExpr.collect((IntegerExpression) dse.oprlist[1]);
+				final String arg2 = manager.numExpr.collect((IntegerExpression) dse.oprlist[2]);
+				Results.constraints.add("(assert (<= " + arg2 + " (str.len " + in_str + ")))");
+				return "(str.++ (str.substr " + in_str + " 0 " + arg1 + ") (str.substr " + in_str + " " + arg2 + " (str.len " + in_str + ")))";
+			});
+			map(StringOrOperation.INSERT, (expr) -> {
+				final DerivedStringExpression dse = (DerivedStringExpression) expr;
+				final String in_str = manager.strExpr.collect((StringExpression) dse.oprlist[0]);
+				final String insert_str = manager.strExpr.collect((StringExpression) dse.oprlist[1]);
+				final String arg1 = manager.numExpr.collect((IntegerExpression) dse.oprlist[2]);
+				Results.constraints.add("(assert (<= " + arg1 + " (str.len " + in_str + ")))");
+				return "(str.++ (str.substr " + in_str + " 0 " + arg1 + ") " + insert_str + " (str.substr " + in_str + " " + arg1 + " (str.len " + in_str + ")))";
+			});
+			map(StringOrOperation.REVERSE, (expr) -> {
+				final DerivedStringExpression dse = (DerivedStringExpression) expr;
+				final String in_str = manager.strExpr.collect(dse.right);
+				String var = "out_str";
+				Results.stringVariables.add("out_str");
+				Results.constraints.add(
+						"(define-fun-rec reverse ((x String) (y String)) Bool " +
+								"(or (and (= x \"\") (= y \"\")) " +
+								"(and (not (= x \"\")) (not (= y \"\")) " +
+								"(let ((x_head (str.at x 0)) " +
+								"(y_head (str.at y (- (str.len y) 1))) " +
+								"(x_tail (str.substr x 1 (- (str.len x) 1))) " +
+								"(y_tail (str.substr y 0 (- (str.len y) 1)))) " +
+								"(and (= x_head y_head) " +
+								"(reverse x_tail y_tail))))))" +
+								"\n(assert (reverse " + in_str + " out_str))"
+				);
+				return var;
 			});
 		}
 	}

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/bytecode/SymbolicStringHandler.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/bytecode/SymbolicStringHandler.java
@@ -125,7 +125,7 @@ public class SymbolicStringHandler {
 					} else {
 						return true;
 					}
-					
+
 				}
 			}
             if(invInst instanceof INVOKESTATIC && cname.equals("java.lang.String") && invInst.getInvokedMethod().getName().equals("valueOf") ){
@@ -354,27 +354,17 @@ public class SymbolicStringHandler {
                     handleIsLetter(invInst, th);
                     return invInst.getNext(th);
                 }
-            } else if(shortName.equals("toUpperCase")){
-                ChoiceGenerator<?> cg;
-                if (!th.isFirstStepInsn()) { // first time around
-                    cg = new PCChoiceGenerator(5);
-                    th.getVM().setNextChoiceGenerator(cg);
-                    return invInst;
-                } else {
-                    handleToUpperCase(invInst, th);
-                    return invInst.getNext(th);
-                }
-            } else if(shortName.equals("toLowerCase")){
-                ChoiceGenerator<?> cg;
-                if (!th.isFirstStepInsn()) { // first time around
-                    cg = new PCChoiceGenerator(5);
-                    th.getVM().setNextChoiceGenerator(cg);
-                    return invInst;
-                } else {
-                    handleToLowerCase(invInst, th);
-                    return invInst.getNext(th);
-                }
-            } else {
+            } else if (shortName.equals("toLowerCase")) {
+				handleToLowerCase(invInst, th);
+			} else if (shortName.equals("toUpperCase")) {
+				handleToUpperCase(invInst, th);
+			} else if (shortName.equals("delete")){
+				handleDelete(invInst, th);
+			}else if (shortName.equals("insert")) {
+                handleInsert(invInst, th);
+            } else if (shortName.equals("reverse")) {
+                handleReverse(invInst, th);
+			} else {
 				throw new RuntimeException("ERROR: symbolic method not handled: " + shortName);
 				//return null;
 			}
@@ -385,223 +375,167 @@ public class SymbolicStringHandler {
 
 	}
 
-
-  public void handleToUpperCase(JVMInvokeInstruction invInst,  ThreadInfo th) {
-
-    StackFrame sf = th.getModifiableTopFrame();
-    Object sym_v = sf.getOperandAttr(0);
-    ChoiceGenerator<?> cg;
-
-    cg = th.getVM().getChoiceGenerator();
-    assert (cg instanceof PCChoiceGenerator) : "expected PCChoiceGenerator, got: " + cg;
-    PathCondition pc;
-    ChoiceGenerator<?> prev_cg = cg.getPreviousChoiceGenerator();
-    while (!((prev_cg == null) || (prev_cg instanceof PCChoiceGenerator))) {
-      prev_cg = prev_cg.getPreviousChoiceGenerator();
-    }
-
-    if (prev_cg == null) {
-      pc = new PathCondition();
-    } else {
-      pc = ((PCChoiceGenerator) prev_cg).getCurrentPC();
-    }
-
-    assert pc != null;
-    if((Integer) cg.getNextChoice() == 0) {  // already an upper case from A - Z
-      if (sym_v != null) {
-        if (sym_v instanceof SymbolicInteger) {
-          pc._addDet(Comparator.GE, (IntegerExpression) sym_v, new IntegerConstant(65));
-          pc._addDet(Comparator.LE, (IntegerExpression) sym_v, new IntegerConstant(90));
-          if (!pc.simplify()) {// not satisfiable
-            th.getVM().getSystemState().setIgnored(true);
-          } else {
-            // pc.solve();
-            ((PCChoiceGenerator) cg).setCurrentPC(pc);
-            // System.out.println(((PCChoiceGenerator) cg).getCurrentPC());
-          }
-        } else if (sym_v instanceof StringSymbolic) {
-          assert false : "unsupported toUpper case";
+    private void handleReverse(JVMInvokeInstruction invInst, ThreadInfo th) {
+        StackFrame sf = ((ThreadInfo) th).getModifiableTopFrame();
+        StringExpression sym_v1 = ((SymbolicStringBuilder) sf.getOperandAttr(0)).getstr();
+        if (sym_v1 == null) {
+            throw new RuntimeException("ERROR: symbolic string method must have one symbolic operand: HandleReverse");
         } else {
-          assert false : "unsupported toUpper case";
-        }
-      }
-    }else if((Integer) cg.getNextChoice() == 1){ // is a lower case, then change it to upper case
-      if(sym_v!=null){
-        if(sym_v instanceof SymbolicInteger){
-          pc._addDet(Comparator.GE, (IntegerExpression) sym_v, new IntegerConstant(97));
-          pc._addDet(Comparator.LE, (IntegerExpression) sym_v, new IntegerConstant(122));
-          if (!pc.simplify()) {// not satisfiable
-            th.getVM().getSystemState().setIgnored(true);
-          } else {
-            ((PCChoiceGenerator) cg).setCurrentPC(pc);
-            IntegerExpression toUpperExp = new BinaryLinearIntegerExpression((IntegerExpression) sym_v, Operator.MINUS, new IntegerConstant(32));
-            sf.setOperandAttr(toUpperExp);
-          }
-        }else if(sym_v instanceof StringSymbolic){
-          assert false : "unsupported toUpper case";
-        } else{
-          assert false : "unsupported toUpper case";
-        }
-      }
-    }else if((Integer) cg.getNextChoice() == 2){ // is not in letter range less than 65, then leave things as is
-      if(sym_v!=null){
-        if(sym_v instanceof SymbolicInteger){
-          pc._addDet(Comparator.LT, (IntegerExpression) sym_v, new IntegerConstant(65));
-          if (!pc.simplify()) {// not satisfiable
-            th.getVM().getSystemState().setIgnored(true);
-          } else {
-            ((PCChoiceGenerator) cg).setCurrentPC(pc);
-          }
-        }else if(sym_v instanceof StringSymbolic){
-          assert false : "unsupported toUpper case";
-        } else{
-          assert false : "unsupported toUpper case";
-        }
-      }
-    }else if((Integer) cg.getNextChoice() == 3){ // is not in letter range between 90-97
-      if(sym_v!=null){
-        if(sym_v instanceof SymbolicInteger){
-          pc._addDet(Comparator.GT, (IntegerExpression) sym_v, new IntegerConstant(90));
-          pc._addDet(Comparator.LT, (IntegerExpression) sym_v, new IntegerConstant(97));
-          if (!pc.simplify()) {// not satisfiable
-            th.getVM().getSystemState().setIgnored(true);
-          } else {
-            // pc.solve();
-            ((PCChoiceGenerator) cg).setCurrentPC(pc);
-            // System.out.println(((PCChoiceGenerator) cg).getCurrentPC());
-          }
-        }else if(sym_v instanceof StringSymbolic){
-          assert false : "unsupported toUpper case";
-        } else{
-          assert false : "unsupported toUpper case";
-        }
-      }
-    }else if((Integer) cg.getNextChoice() == 4) { // is not in letter greater than 122
-      if (sym_v != null) {
-        if (sym_v instanceof SymbolicInteger) {
-          pc._addDet(Comparator.GT, (IntegerExpression) sym_v, new IntegerConstant(122));
-          if (!pc.simplify()) {// not satisfiable
-            th.getVM().getSystemState().setIgnored(true);
-          } else {
-            // pc.solve();
-            ((PCChoiceGenerator) cg).setCurrentPC(pc);
-            // System.out.println(((PCChoiceGenerator) cg).getCurrentPC());
-          }
-        } else if (sym_v instanceof StringSymbolic) {
-          assert false : "unsupported toUpper case";
-        } else {
-          assert false : "unsupported toUpper case";
-        }
-      }
-    }
-  }
+            int s1 = sf.pop();
+            StringExpression result = sym_v1._reverse();
 
-  public void handleToLowerCase(JVMInvokeInstruction invInst,  ThreadInfo th) {
+            ElementInfo objRef = th.getHeap().newString("", th);
 
-    StackFrame sf = th.getModifiableTopFrame();
-    Object sym_v = sf.getOperandAttr(0);
-    ChoiceGenerator<?> cg;
-
-    cg = th.getVM().getChoiceGenerator();
-    assert (cg instanceof PCChoiceGenerator) : "expected PCChoiceGenerator, got: " + cg;
-    PathCondition pc;
-    ChoiceGenerator<?> prev_cg = cg.getPreviousChoiceGenerator();
-    while (!((prev_cg == null) || (prev_cg instanceof PCChoiceGenerator))) {
-      prev_cg = prev_cg.getPreviousChoiceGenerator();
+            sf.push(objRef.getObjectRef(), true);
+            sf.setOperandAttr(result);
+        }
     }
 
-    if (prev_cg == null) {
-      pc = new PathCondition();
-    } else {
-      pc = ((PCChoiceGenerator) prev_cg).getCurrentPC();
-    }
+	private void handleInsert(JVMInvokeInstruction invInst, ThreadInfo th) {
+		StackFrame sf = th.getModifiableTopFrame();
+		StringExpression sym_v1 = (StringExpression) sf.getOperandAttr(0);
+		IntegerExpression sym_v2 = (IntegerExpression) sf.getOperandAttr(1);
+		StringExpression sym_v3 = ((SymbolicStringBuilder) sf.getOperandAttr(2)).getstr();
 
-    assert pc != null;
-    if((Integer) cg.getNextChoice() == 0) {  // already an upper case from A - Z
-      if (sym_v != null) {
-        if (sym_v instanceof SymbolicInteger) {
-          pc._addDet(Comparator.GE, (IntegerExpression) sym_v, new IntegerConstant(65));
-          pc._addDet(Comparator.LE, (IntegerExpression) sym_v, new IntegerConstant(90));
-          IntegerExpression toLowerExp = new BinaryLinearIntegerExpression((IntegerExpression) sym_v, Operator.PLUS, new IntegerConstant(32));
-          if (!pc.simplify()) {// not satisfiable
-            th.getVM().getSystemState().setIgnored(true);
-          } else {
-            ((PCChoiceGenerator) cg).setCurrentPC(pc);
-            sf.setOperandAttr(toLowerExp);          }
-        } else if (sym_v instanceof StringSymbolic) {
-          assert false : "unsupported toUpper case";
-        } else {
-          assert false : "unsupported toUpper case";
-        }
-      }
-    }else if((Integer) cg.getNextChoice() == 1){ // is a lower case, then change it to upper case
-      if(sym_v!=null){
-        if(sym_v instanceof SymbolicInteger){
-          pc._addDet(Comparator.GE, (IntegerExpression) sym_v, new IntegerConstant(97));
-          pc._addDet(Comparator.LE, (IntegerExpression) sym_v, new IntegerConstant(122));
-          if (!pc.simplify()) {// not satisfiable
-            th.getVM().getSystemState().setIgnored(true);
-          } else {
-            ((PCChoiceGenerator) cg).setCurrentPC(pc);
-          }
-        }else if(sym_v instanceof StringSymbolic){
-          assert false : "unsupported toUpper case";
-        } else{
-          assert false : "unsupported toUpper case";
-        }
-      }
-    }else if((Integer) cg.getNextChoice() == 2){ // is not in letter range less than 65, then leave things as is
-      if(sym_v!=null){
-        if(sym_v instanceof SymbolicInteger){
-          pc._addDet(Comparator.LT, (IntegerExpression) sym_v, new IntegerConstant(65));
-          if (!pc.simplify()) {// not satisfiable
-            th.getVM().getSystemState().setIgnored(true);
-          } else {
-            ((PCChoiceGenerator) cg).setCurrentPC(pc);
-          }
-        }else if(sym_v instanceof StringSymbolic){
-          assert false : "unsupported toUpper case";
-        } else{
-          assert false : "unsupported toUpper case";
-        }
-      }
-    }else if((Integer) cg.getNextChoice() == 3){ // is not in letter range between 90-97
-      if(sym_v!=null){
-        if(sym_v instanceof SymbolicInteger){
-          pc._addDet(Comparator.GT, (IntegerExpression) sym_v, new IntegerConstant(90));
-          pc._addDet(Comparator.LT, (IntegerExpression) sym_v, new IntegerConstant(97));
-          if (!pc.simplify()) {// not satisfiable
-            th.getVM().getSystemState().setIgnored(true);
-          } else {
-            // pc.solve();
-            ((PCChoiceGenerator) cg).setCurrentPC(pc);
-            // System.out.println(((PCChoiceGenerator) cg).getCurrentPC());
-          }
-        }else if(sym_v instanceof StringSymbolic){
-          assert false : "unsupported toUpper case";
-        } else{
-          assert false : "unsupported toUpper case";
-        }
-      }
-    }else if((Integer) cg.getNextChoice() == 4) { // is not in letter greater than 122
-      if (sym_v != null) {
-        if (sym_v instanceof SymbolicInteger) {
-          pc._addDet(Comparator.GT, (IntegerExpression) sym_v, new IntegerConstant(122));
-          if (!pc.simplify()) {// not satisfiable
-            th.getVM().getSystemState().setIgnored(true);
-          } else {
-            // pc.solve();
-            ((PCChoiceGenerator) cg).setCurrentPC(pc);
-            // System.out.println(((PCChoiceGenerator) cg).getCurrentPC());
-          }
-        } else if (sym_v instanceof StringSymbolic) {
-          assert false : "unsupported toUpper case";
-        } else {
-          assert false : "unsupported toUpper case";
-        }
-      }
-    }
-  }
+		if (sym_v1 == null && sym_v2 == null && sym_v3 == null) {
+			throw new RuntimeException("ERROR: symbolic string method must have one symbolic operand: HandleDelete");
+		} else {
+			int s1 = sf.pop();
+			int s2 = sf.pop(); // indices get popped in reverse order
+			int s3 = sf.pop();
+			StringExpression result = null;
+			if (sym_v1 == null) { //string arg concrete
+				ElementInfo e1 = th.getElementInfo(s1);
+				String val1 = e1.asString();
+				sym_v1 = new StringConstant(val1);
+				if (sym_v2 == null) {//int arg concrete so stringbuilder symbolic
+					int val2 = s2;
+					result = sym_v3._insert(sym_v1, val2);
+				} else {//int arg symbolic
+					if (sym_v3 == null) { //concrete string
+						ElementInfo e3 = th.getElementInfo(s3);
+						String val3 = e3.asString();
+						sym_v3 = new StringConstant(val3);
+					}
+					result = sym_v3._insert(sym_v1, sym_v2);
+				}
+			} else { // string arg symbolic
+				if (sym_v2 == null) {
+					if (sym_v3 == null) {
+						ElementInfo e3 = th.getElementInfo(s3);
+						String val3 = e3.asString();
+						sym_v3 = new StringConstant(val3);
+					}
+					int val2 = s2;
+					result = sym_v3._insert(sym_v1, val2);
+				} else {
+					if (sym_v3 == null) {
+						ElementInfo e3 = th.getElementInfo(s3);
+						String val3 = e3.asString();
+						sym_v3 = new StringConstant(val3);
+					}
+					result = sym_v3._insert(sym_v1, sym_v2);
+				}
+			}
+			ElementInfo objRef = th.getHeap().newString("", th);
+			sf.push(objRef.getObjectRef(), true);
+			sf.setOperandAttr(result);
+		}
+
+	}
+
+	private Instruction handleDelete(JVMInvokeInstruction invInst, ThreadInfo th) {
+		StackFrame sf = th.getModifiableTopFrame();
+		IntegerExpression sym_v1 = (IntegerExpression) sf.getOperandAttr(0);
+		IntegerExpression sym_v2 = (IntegerExpression) sf.getOperandAttr(1);
+		StringExpression sym_v3 = ((SymbolicStringBuilder) sf.getOperandAttr(2)).getstr(); // nps: unsure this is correct methodology
+
+		if (sym_v1 == null && sym_v2 == null && sym_v3 == null) {
+			throw new RuntimeException("ERROR: symbolic string method must have one symbolic operand: HandleDelete");
+		} else {
+			int s2 = sf.pop();
+			int s1 = sf.pop(); // indices get popped in reverse order
+			int s3 = sf.pop();
+			StringExpression result = null;
+			if (sym_v1 == null) { //operand concrete
+				int val1 = s1;
+				if (sym_v2 == null) {//concrete so string symbolic
+					int val2 = s2;
+					result = sym_v3._delete(val1, val2);
+				} else {
+					if (sym_v3 == null) { //concrete string
+						ElementInfo e3 = th.getElementInfo(s3);
+						String val3 = e3.asString();
+						sym_v3 = new StringConstant(val3);
+					}
+					result = sym_v3._delete(val1, sym_v2);
+				}
+			} else { // int1 symblic
+				if (sym_v2 == null) {
+					if (sym_v3 == null) {
+						ElementInfo e3 = th.getElementInfo(s3);
+						String val3 = e3.asString();
+						sym_v3 = new StringConstant(val3);
+					}
+					int val2 = s2;
+					result = sym_v3._delete(sym_v1, val2);
+				} else {
+					if (sym_v3 == null) {
+						ElementInfo e3 = th.getElementInfo(s3);
+						String val3 = e3.asString();
+						sym_v3 = new StringConstant(val3);
+					}
+					result = sym_v3._delete(sym_v1, sym_v2);
+				}
+			}
+			ElementInfo objRef = th.getHeap().newString("", th);
+			sf.push(objRef.getObjectRef(), true);
+			sf.setOperandAttr(result);
+		}
+		return null;
+	}
+
+	public void handleToLowerCase(JVMInvokeInstruction invInst, ThreadInfo th) {
+		// throw new RuntimeException("ERROR: symbolic string method not Implemented - ToLowerCase");
+		StackFrame sf = th.getModifiableTopFrame();
+		StringExpression sym_v1 = (StringExpression) sf.getOperandAttr(0);
+		int s1 = sf.pop();
+
+		if (sym_v1 == null) {
+			ElementInfo e1 = th.getElementInfo(s1);
+			String val1 = e1.asString();
+			sym_v1 = new StringConstant(val1);
+		}
+		StringExpression result = sym_v1._toLowerCase();
+
+		ElementInfo  objRef = th.getHeap().newString("", th); /*
+		 * dummy String
+		 * Object
+		 */
+		sf.push(objRef.getObjectRef(), true);
+		sf.setOperandAttr(result);
+	}
+
+	public void handleToUpperCase(JVMInvokeInstruction invInst, ThreadInfo th) {
+		// throw new RuntimeException("ERROR: symbolic string method not Implemented - ToUpperCase");
+		StackFrame sf = th.getModifiableTopFrame();
+		StringExpression sym_v1 = (StringExpression) sf.getOperandAttr(0);
+		int s1 = sf.pop();
+
+		if (sym_v1 == null) {
+			ElementInfo e1 = th.getElementInfo(s1);
+			String val1 = e1.asString();
+			sym_v1 = new StringConstant(val1);
+		}
+		StringExpression result = sym_v1._toUpperCase();
+
+		ElementInfo  objRef = th.getHeap().newString("", th); /*
+		 * dummy String
+		 * Object
+		 */
+		sf.push(objRef.getObjectRef(), true);
+		sf.setOperandAttr(result);
+	}
 
 	private void handleIsLetter(JVMInvokeInstruction invInst, ThreadInfo th) {
 		StackFrame sf = th.getModifiableTopFrame();
@@ -681,29 +615,29 @@ public class SymbolicStringHandler {
         if(sym_v instanceof SymbolicInteger){
           pc._addDet(Comparator.GT, (IntegerExpression) sym_v, new IntegerConstant(90));
           pc._addDet(Comparator.LT, (IntegerExpression) sym_v, new IntegerConstant(97));
-          if (!pc.simplify()) {// not satisfiable
-            th.getVM().getSystemState().setIgnored(true);
-          } else {
-            // pc.solve();
-            ((PCChoiceGenerator) cg).setCurrentPC(pc);
-            // System.out.println(((PCChoiceGenerator) cg).getCurrentPC());
-          }
-        }else if(sym_v instanceof StringSymbolic){
-          assert false: "unsupported is letter case";
-        } else{
-          assert false: "unsupported is letter case";
-        }
-      }
-    }else if((Integer) cg.getNextChoice() == 4){  // is not in letter greater than 122
-      if(sym_v!=null){
-        if(sym_v instanceof SymbolicInteger){
-          pc._addDet(Comparator.GT, (IntegerExpression) sym_v, new IntegerConstant(122));
-          if (!pc.simplify()) {// not satisfiable
-            th.getVM().getSystemState().setIgnored(true);
-          } else {
-            // pc.solve();
-            ((PCChoiceGenerator) cg).setCurrentPC(pc);
-            // System.out.println(((PCChoiceGenerator) cg).getCurrentPC());
+			if (!pc.simplify()) {// not satisfiable
+				th.getVM().getSystemState().setIgnored(true);
+			} else {
+				// pc.solve();
+				((PCChoiceGenerator) cg).setCurrentPC(pc);
+				// System.out.println(((PCChoiceGenerator) cg).getCurrentPC());
+			}
+		} else if (sym_v instanceof StringSymbolic) {
+			assert false : "unsupported is letter case";
+		} else {
+			assert false : "unsupported is letter case";
+		}
+	  }
+	} else if ((Integer) cg.getNextChoice() == 4) {  // is not in letter greater than 122
+		if (sym_v != null) {
+			if (sym_v instanceof SymbolicInteger) {
+				pc._addDet(Comparator.GT, (IntegerExpression) sym_v, new IntegerConstant(122));
+				if (!pc.simplify()) {// not satisfiable
+					th.getVM().getSystemState().setIgnored(true);
+				} else {
+					// pc.solve();
+					((PCChoiceGenerator) cg).setCurrentPC(pc);
+					// System.out.println(((PCChoiceGenerator) cg).getCurrentPC());
           }
         }else if(sym_v instanceof StringSymbolic){
           assert false: "unsupported is letter case";
@@ -748,7 +682,6 @@ public class SymbolicStringHandler {
 			sf.setOperandAttr(result);
 		}
 		return bresult; // not used
-
 	}
 
 	public void handleLength(JVMInvokeInstruction invInst, ThreadInfo th) {

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/string/StringExpression.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/string/StringExpression.java
@@ -250,7 +250,15 @@ public abstract class StringExpression extends Expression {
     return new DerivedStringExpression(StringOperator.TRIM, this);
   }
 
-/* concat */
+	public StringExpression _toLowerCase() {
+		return new DerivedStringExpression(StringOperator.TOLOWERCASE, this);
+	}
+
+	public StringExpression _toUpperCase() {
+		return new DerivedStringExpression(StringOperator.TOUPPERCASE, this);
+	}
+
+	/* concat */
   public StringExpression _concat(String s) {
     return new DerivedStringExpression(this, StringOperator.CONCAT, new StringConstant(s));
   }
@@ -384,7 +392,81 @@ public StringExpression _replaceFirst(StringExpression t, String r) {
 	    return new DerivedStringExpression(StringOperator.REPLACEFIRST, l );
 	  }
 
-/* valueOf */
+	/* delete */
+
+	public StringExpression _delete(Integer int1, Integer int2) {
+		Expression l[] = new Expression[3];
+		l[0] = this;
+		l[1] = new IntegerConstant(int1);
+		l[2] = new IntegerConstant(int2);
+		return new DerivedStringExpression(StringOperator.DELETE, l);
+	}
+
+	public StringExpression _delete(IntegerExpression intex1, Integer int2) {
+		Expression l[] = new Expression[3];
+		l[0] = this;
+		l[1] = intex1;
+		l[2] = new IntegerConstant(int2);
+		return new DerivedStringExpression(StringOperator.DELETE, l);
+	}
+
+	public StringExpression _delete(Integer int1, IntegerExpression intex2) {
+		Expression l[] = new Expression[3];
+		l[0] = this;
+		l[1] = new IntegerConstant(int1);
+		l[2] = intex2;
+		return new DerivedStringExpression(StringOperator.DELETE, l);
+	}
+
+	public StringExpression _delete(IntegerExpression intex1, IntegerExpression intex2) {
+		Expression l[] = new Expression[3];
+		l[0] = this;
+		l[1] = intex1;
+		l[2] = intex2;
+		return new DerivedStringExpression(StringOperator.DELETE, l);
+	}
+
+	/* insert */
+
+	public StringExpression _insert(String str1, Integer int2) {
+		Expression l[] = new Expression[3];
+		l[0] = this;
+		l[1] = new StringConstant(str1);
+		l[2] = new IntegerConstant(int2);
+		return new DerivedStringExpression(StringOperator.INSERT, l);
+	}
+
+	public StringExpression _insert(StringExpression str1, Integer int2) {
+		Expression l[] = new Expression[3];
+		l[0] = this;
+		l[1] = str1;
+		l[2] = new IntegerConstant(int2);
+		return new DerivedStringExpression(StringOperator.INSERT, l);
+	}
+
+	public StringExpression _insert(StringExpression str1, IntegerExpression intex2) {
+		Expression l[] = new Expression[3];
+		l[0] = this;
+		l[1] = str1;
+		l[2] = intex2;
+		return new DerivedStringExpression(StringOperator.INSERT, l);
+	}
+
+	public StringExpression _insert(String str1, IntegerExpression intex2) {
+		Expression l[] = new Expression[3];
+		l[0] = this;
+		l[1] = new StringConstant(str1);
+		l[2] = intex2;
+		return new DerivedStringExpression(StringOperator.INSERT, l);
+	}
+
+	/* reverse */
+
+	public StringExpression _reverse() {
+		return new DerivedStringExpression(StringOperator.REVERSE, this);
+	}
+
+	/* valueOf */
 
 public static StringExpression _valueOf(IntegerExpression t) {
         Expression l[] = new Expression[1];

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/string/StringOperator.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/string/StringOperator.java
@@ -3,16 +3,16 @@
  * Administrator of the National Aeronautics and Space Administration.
  * All rights reserved.
  *
- * Symbolic Pathfinder (jpf-symbc) is licensed under the Apache License, 
+ * Symbolic Pathfinder (jpf-symbc) is licensed under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
- * 
- *        http://www.apache.org/licenses/LICENSE-2.0. 
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0.
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and 
+ * See the License for the specific language governing permissions and
  * limitations under the License.
  */
 
@@ -52,24 +52,28 @@ package gov.nasa.jpf.symbc.string;
 
 
 public enum StringOperator {
-  CONCAT("concat"),
-  REPLACE("replace"),
-  TRIM("trim"),
-  SUBSTRING("substring"),
-  REPLACEFIRST("replacefirst"),
-  REPLACEALL("replaceall"),
-  TOLOWERCASE("tolowercase"),
-  TOUPPERCASE("touppercase"),
-  VALUEOF("valueof");
+    CONCAT("concat"),
+    REPLACE("replace"),
+    TRIM("trim"),
+    SUBSTRING("substring"),
+    REPLACEFIRST("replacefirst"),
+    REPLACEALL("replaceall"),
+    TOLOWERCASE("tolowercase"),
+    TOUPPERCASE("touppercase"),
+    VALUEOF("valueof"),
+    DELETE("delete"),
+    CHARAT("charAt"),
+    INSERT("insert"),
+    REVERSE("reverse");
 
-  private final String str;
+    private final String str;
 
-  StringOperator(String str) {
-    this.str = str;
-  }
+    StringOperator(String str) {
+        this.str = str;
+    }
 
-  @Override
-  public String toString() {
-    return str;
-  }
+    @Override
+    public String toString() {
+        return str;
+    }
 }


### PR DESCRIPTION
- Added support for `StringBuilder` methods: `delete`, `insert`, and `reverse`.

- Fixed translation semantics for replacement. Where Java defaults to `replaceAll` the smt-lib 'str.replace' operator is a `replaceFirst` operation.

- Changed `isEmpty` translation to '(= 0 (str.len' as 'empty' is not an smt-lib supported predicate

- Added smt-lib case conversion support for z3 satisfiability checks as recursive functions. This was implemented before seeing the current handling of case conversion by SPF and I am not sure that it would be preferable.