### PR TITLE
implemented and logical op and mixed.

### DIFF
--- a/jpf-sv-comp
+++ b/jpf-sv-comp
@@ -41,7 +41,7 @@ mkdir -p $DIR/target/classes
 # create configuration file
 echo "target=Main" > $DIR/config.jpf
 echo "classpath=`pwd`/jpf-symbc/build/classes:$DIR/target/classes:$CLASSPATH_ADDED" >> $DIR/config.jpf
-echo "symbolic.dp=z3" >> $DIR/config.jpf
+echo "symbolic.dp=z3bitvector" >> $DIR/config.jpf
 echo "symbolic.bvlength=64" >> $DIR/config.jpf
 echo "search.depth_limit=13" >> $DIR/config.jpf
 echo "symbolic.strings=true" >> $DIR/config.jpf

--- a/jpf-sv-comp
+++ b/jpf-sv-comp
@@ -41,7 +41,7 @@ mkdir -p $DIR/target/classes
 # create configuration file
 echo "target=Main" > $DIR/config.jpf
 echo "classpath=`pwd`/jpf-symbc/build/classes:$DIR/target/classes:$CLASSPATH_ADDED" >> $DIR/config.jpf
-echo "symbolic.dp=z3bitvector" >> $DIR/config.jpf
+echo "symbolic.dp=z3" >> $DIR/config.jpf
 echo "symbolic.bvlength=64" >> $DIR/config.jpf
 echo "search.depth_limit=13" >> $DIR/config.jpf
 echo "symbolic.strings=true" >> $DIR/config.jpf

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/numeric/SymbolicConstraintsGeneral.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/numeric/SymbolicConstraintsGeneral.java
@@ -125,14 +125,7 @@ public class SymbolicConstraintsGeneral {
          * work otherwise and the solver gets filled up with wrong assertions,
          * e.g. with Z3.
          */
-        ProblemGeneral tempPb = null;
-
-        try {
-            tempPb = PCParser.parse(pc, pb);
-        } catch (Exception e) {
-            e.printStackTrace();
-            this.result = Boolean.FALSE;
-        }
+        ProblemGeneral tempPb = PCParser.parse(pc, pb);
 
         if (tempPb == null)
             result = Boolean.FALSE;

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/numeric/SymbolicConstraintsGeneral.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/numeric/SymbolicConstraintsGeneral.java
@@ -125,7 +125,14 @@ public class SymbolicConstraintsGeneral {
          * work otherwise and the solver gets filled up with wrong assertions,
          * e.g. with Z3.
          */
-        ProblemGeneral tempPb = PCParser.parse(pc, pb);
+        ProblemGeneral tempPb = null;
+
+        try {
+            tempPb = PCParser.parse(pc, pb);
+        } catch (Exception e) {
+            e.printStackTrace();
+            this.result = Boolean.FALSE;
+        }
 
         if (tempPb == null)
             result = Boolean.FALSE;
@@ -139,7 +146,6 @@ public class SymbolicConstraintsGeneral {
                             PCParser.getExpression((IntegerExpression) Observations.lastObservedSymbolicExpression));
                 }
             }
-
             result = pb.solve();
         }
 

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/numeric/solvers/ProblemZ3.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/numeric/solvers/ProblemZ3.java
@@ -975,7 +975,8 @@ public class ProblemZ3 extends ProblemGeneral {
 
 	@Override
 	public Object and(long value, Object exp) {
-		throw new RuntimeException("## Error Z3 \n");
+		// hardcoded this to 64 because in config the bitvector length is set to 64
+		return ctx.mkBVAND(toBV(ctx, (Expr<?>) exp, 64), ctx.mkBV(value, 64));
 	}
 
 	@Override
@@ -1065,8 +1066,22 @@ public class ProblemZ3 extends ProblemGeneral {
 
 	@Override
 	public Object mixed(Object exp1, Object exp2) {
-		// TODO Auto-generated method stub
-		throw new RuntimeException("## Error Z3 \n");
+
+		Expr e1 = (Expr) exp1;
+		Expr e2 = (Expr) exp2;
+
+		Sort s1 = e1.getSort();
+		Sort s2 = e2.getSort();
+
+		// Int == Real  →  toReal(Int) == Real
+		if (s1.equals(ctx.getIntSort()) && s2.equals(ctx.getRealSort())) {
+			e1 = ctx.mkInt2Real((IntExpr) e1);
+		}
+		else if (s1.equals(ctx.getRealSort()) && s2.equals(ctx.getIntSort())) {
+			e2 = ctx.mkInt2Real((IntExpr) e2);
+		}
+
+		return ctx.mkEq(e1, e2); // mkEq needs both args to be of the same type.
 	}
 
     @Override
@@ -1077,7 +1092,7 @@ public class ProblemZ3 extends ProblemGeneral {
 	@Override
 	public double getRealValueSup(Object dpVar) {
 		// TODO Auto-generated method stub
-	    throw new RuntimeException("## Error Z3 \n");//return 0;
+	    throw new UnsupportedOperationException("## Error Z3: getRealValueSup not implemented \n");//return 0;
 	}
 
 	@Override
@@ -1205,6 +1220,34 @@ public class ProblemZ3 extends ProblemGeneral {
 	// (e.g., 1.0E-10 → "0.0000000001")
 	private String toPlainDecimalString(double val) {
 		return BigDecimal.valueOf(val).toPlainString();
+	}
+
+	// Helper method for casting into a bitvector
+	public static BitVecExpr toBV(Context ctx, Expr<?> e, int n) {
+		Sort s = e.getSort();
+
+		if (e instanceof IntExpr) {
+			// modulo 2^n
+			return (BitVecExpr) ctx.mkInt2BV(n, (IntExpr) e);
+		}
+
+		if (e instanceof BitVecExpr) {
+			BitVecExpr bv = (BitVecExpr) e;
+			int w = ((BitVecSort) s).getSize();
+			if (w == n) return bv;
+
+			if (w > n) {
+				// in case of an overflow :truncate high bits: take low n bits
+				return (BitVecExpr) ctx.mkExtract(n - 1, 0, bv);
+			} else {
+				// widen: choose policy; usually zero-extend for “bit pattern”
+				int extra = n - w;
+				return (BitVecExpr) ctx.mkZeroExt(extra, bv);
+				// or signed: ctx.mkSignExt(extra, bv)
+			}
+		}
+
+		throw new IllegalArgumentException("Can't convert sort " + s + " to BitVec(" + n + ")");
 	}
 
 }

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/numeric/solvers/ProblemZ3.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/numeric/solvers/ProblemZ3.java
@@ -975,7 +975,6 @@ public class ProblemZ3 extends ProblemGeneral {
 
 	@Override
 	public Object and(long value, Object exp) {
-		// hardcoded this to 64 because in config the bitvector length is set to 64
 		return ctx.mkBVAND(toBV(ctx, (Expr<?>) exp, SymbolicInstructionFactory.bvlength), ctx.mkBV(value, SymbolicInstructionFactory.bvlength));
 	}
 

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/numeric/solvers/ProblemZ3.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/numeric/solvers/ProblemZ3.java
@@ -980,52 +980,52 @@ public class ProblemZ3 extends ProblemGeneral {
 
 	@Override
 	public Object and(Object exp, long value) {
-		throw new RuntimeException("## Error Z3 \n");
+		throw new RuntimeException("## Error Z3: and not implemented \n");
 	}
 
 	@Override
 	public Object and(Object exp1, Object exp2) {
-		throw new RuntimeException("## Error Z3 \n");
+		throw new RuntimeException("## Error Z3: and not implemented \n");
 	}
 
 	@Override
 	public Object or(long value, Object exp) {
-		throw new RuntimeException("## Error Z3 \n");
+		throw new RuntimeException("## Error Z3: or not implemented \n");
 	}
 
 	@Override
 	public Object or(Object exp, long value) {
-		throw new RuntimeException("## Error Z3 \n");
+		throw new RuntimeException("## Error Z3: or not implemented \n");
 	}
 
 	@Override
 	public Object or(Object exp1, Object exp2) {
-		throw new RuntimeException("## Error Z3 \n");
+		throw new RuntimeException("## Error Z3: or not implemented \n");
 	}
 
 	@Override
 	public Object xor(long value, Object exp) {
-		throw new RuntimeException("## Error Z3 \n");
+		throw new RuntimeException("## Error Z3: xor not implemented \n");
 	}
 
 	@Override
 	public Object xor(Object exp, long value) {
-		throw new RuntimeException("## Error Z3 \n");
+		throw new RuntimeException("## Error Z3: xor not implemented \n");
 	}
 
 	@Override
 	public Object xor(Object exp1, Object exp2) {
-		throw new RuntimeException("## Error Z3 \n");
+		throw new RuntimeException("## Error Z3: xor not implemented \n");
 	}
 
 	@Override
 	public Object shiftL(long value, Object exp) {
-		throw new RuntimeException("## Error Z3 \n");
+		throw new RuntimeException("## Error Z3: shiftL not implemented \n");
 	}
 
 	@Override
 	public Object shiftL(Object exp, long value) {
-		throw new RuntimeException("## Error Z3 \n");
+		throw new RuntimeException("## Error Z3: shiftL not implemented \n");
 	}
 
 	@Override
@@ -1035,32 +1035,32 @@ public class ProblemZ3 extends ProblemGeneral {
 
 	@Override
 	public Object shiftR(long value, Object exp) {
-		throw new RuntimeException("## Error Z3 \n");
+		throw new RuntimeException("## Error Z3: shiftR not implemented \n");
 	}
 
 	@Override
 	public Object shiftR(Object exp, long value) {
-		throw new RuntimeException("## Error Z3 \n");
+		throw new RuntimeException("## Error Z3: shiftR not implemented \n");
 	}
 
 	@Override
 	public Object shiftR(Object exp1, Object exp2) {
-		throw new RuntimeException("## Error Z3 \n");
+		throw new RuntimeException("## Error Z3: shiftR not implemented \n");
 	}
 
 	@Override
 	public Object shiftUR(long value, Object exp) {
-		throw new RuntimeException("## Error Z3 \n");
+		throw new RuntimeException("## Error Z3: shiftUR not implemented \n");
 	}
 
 	@Override
 	public Object shiftUR(Object exp, long value) {
-		throw new RuntimeException("## Error Z3 \n");
+		throw new RuntimeException("## Error Z3: shiftUR not implemented \n");
 	}
 
 	@Override
 	public Object shiftUR(Object exp1, Object exp2) {
-		throw new RuntimeException("## Error Z3 \n");
+		throw new RuntimeException("## Error Z3: shiftUR not implemented \n");
 	}
 
 	@Override
@@ -1085,7 +1085,7 @@ public class ProblemZ3 extends ProblemGeneral {
 
     @Override
     public double getRealValueInf(Object dpVar) {
-        throw new RuntimeException("## Error Z3 \n");//return 0;
+        throw new RuntimeException("## Error Z3: getRealValueInf not implemented \n");//return 0;
     }
 
 	@Override
@@ -1113,7 +1113,7 @@ public class ProblemZ3 extends ProblemGeneral {
 	@Override
 	public void postLogicalOR(Object[] constraint) {
 		// TODO Auto-generated method stub
-		throw new RuntimeException("## Error Z3 \n");
+		throw new RuntimeException("## Error Z3 : postLogicalOR not implemented\n");
 	}
 
     // Added by Aymeric to support arrays

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/numeric/solvers/ProblemZ3.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/numeric/solvers/ProblemZ3.java
@@ -612,13 +612,20 @@ public class ProblemZ3 extends ProblemGeneral {
 		}
 	}
 
-	public Object rem(Object exp, long value) {// added by corina
-		try{
+	public Object rem(Object exp, long value) {
+		try {
+			IntExpr e1 = (IntExpr) exp;
+			IntExpr e2 = ctx.mkInt(value);
+			IntExpr zero = ctx.mkInt(0);
 
-			return  ctx.mkRem((IntExpr) exp, ctx.mkInt(value));
+			// Java: (dividend < 0) ? -(-dividend % divisor) : (dividend % divisor)
+			return ctx.mkITE(
+					ctx.mkLt(e1, zero),
+					ctx.mkUnaryMinus(ctx.mkMod(ctx.mkUnaryMinus(e1), e2)),
+					ctx.mkMod(e1, e2)
+			);
 		} catch (Exception e) {
-			e.printStackTrace();
-			throw new RuntimeException("## Error Z3: Exception caught in Z3 JNI: \n" + e);
+			throw new RuntimeException("## Error Z3: rem(Object, long) failed.\n" + e);
 		}
 	}
 	public Object rem(long value, Object exp) {// added by corina
@@ -980,118 +987,145 @@ public class ProblemZ3 extends ProblemGeneral {
 
 	@Override
 	public Object and(Object exp, long value) {
-		throw new RuntimeException("## Error Z3: and not implemented \n");
+		throw new RuntimeException("## Error Z3: logical-AND not implemented in z3 \n");
 	}
 
 	@Override
 	public Object and(Object exp1, Object exp2) {
-		throw new RuntimeException("## Error Z3: and not implemented \n");
+		throw new RuntimeException("## Error Z3: logical-AND not implemented in z3\n");
 	}
 
 	@Override
 	public Object or(long value, Object exp) {
-		throw new RuntimeException("## Error Z3: or not implemented \n");
+		throw new RuntimeException("## Error Z3: logical-OR not implemented in solver z3 \n");
 	}
 
 	@Override
 	public Object or(Object exp, long value) {
-		throw new RuntimeException("## Error Z3: or not implemented \n");
+		throw new RuntimeException("## Error Z3: logical-OR not implemented in solver z3 \n");
 	}
 
 	@Override
 	public Object or(Object exp1, Object exp2) {
-		throw new RuntimeException("## Error Z3: or not implemented \n");
+		throw new RuntimeException("## Error Z3: logical-OR not implemented in solver z3 \n");
 	}
 
 	@Override
 	public Object xor(long value, Object exp) {
-		throw new RuntimeException("## Error Z3: xor not implemented \n");
+		throw new RuntimeException("## Error Z3: logical-xor not implemented in solver z3\n");
 	}
 
 	@Override
 	public Object xor(Object exp, long value) {
-		throw new RuntimeException("## Error Z3: xor not implemented \n");
+		throw new RuntimeException("## Error Z3: logical-xor not implemented in solver z3\n");
 	}
 
 	@Override
 	public Object xor(Object exp1, Object exp2) {
-		throw new RuntimeException("## Error Z3: xor not implemented \n");
+		throw new RuntimeException("## Error Z3: logical-xor not implemented in solver z3\n");
 	}
 
 	@Override
 	public Object shiftL(long value, Object exp) {
-		throw new RuntimeException("## Error Z3: shiftL not implemented \n");
+		throw new RuntimeException("## Error Z3: logical-shiftL not implemented in solver z3\n");
 	}
 
 	@Override
 	public Object shiftL(Object exp, long value) {
-		throw new RuntimeException("## Error Z3: shiftL not implemented \n");
+		throw new RuntimeException("## Error Z3: logical-shiftL not implemented in solver z3 \n");
 	}
 
 	@Override
 	public Object shiftL(Object exp1, Object exp2) {
-		throw new RuntimeException("## Error Z3 \n");
+		throw new RuntimeException("## Error Z3: logical-shiftL not implemented in solver z3 \n");
 	}
 
 	@Override
 	public Object shiftR(long value, Object exp) {
-		throw new RuntimeException("## Error Z3: shiftR not implemented \n");
+		throw new RuntimeException("## Error Z3: logical-shiftR not implemented in solver z3 \n");
 	}
 
 	@Override
 	public Object shiftR(Object exp, long value) {
-		throw new RuntimeException("## Error Z3: shiftR not implemented \n");
+		throw new RuntimeException("## Error Z3: logical-shiftR not implemented in solver z3 \n");
 	}
 
 	@Override
 	public Object shiftR(Object exp1, Object exp2) {
-		throw new RuntimeException("## Error Z3: shiftR not implemented \n");
+		throw new RuntimeException("## Error Z3: logical-shiftR not implemented in solver z3 \n");
 	}
 
 	@Override
 	public Object shiftUR(long value, Object exp) {
-		throw new RuntimeException("## Error Z3: shiftUR not implemented \n");
+		throw new RuntimeException("## Error Z3: logical-shiftUR not implemented in solver z3 \n");
 	}
 
 	@Override
 	public Object shiftUR(Object exp, long value) {
-		throw new RuntimeException("## Error Z3: shiftUR not implemented \n");
+		throw new RuntimeException("## Error Z3: logical-shiftUR not implemented in solver z3 \n");
 	}
 
 	@Override
 	public Object shiftUR(Object exp1, Object exp2) {
-		throw new RuntimeException("## Error Z3: shiftUR not implemented \n");
+		throw new RuntimeException("## Error Z3: logical-shiftUR not implemented in solver z3 \n");
 	}
 
 	@Override
 	public Object mixed(Object exp1, Object exp2) {
-
+		// 1. Initial Validation (No trust, no crashes)
+		if (!(exp1 instanceof Expr) || !(exp2 instanceof Expr)) {
+			throw new RuntimeException("## Error Z3 Theory Bridge: mixed() received non-Expr types. "
+					+ "exp1: " + (exp1 != null ? exp1.getClass().getSimpleName() : "null")
+					+ ", exp2: " + (exp2 != null ? exp2.getClass().getSimpleName() : "null"));
+		}
 		Expr e1 = (Expr) exp1;
 		Expr e2 = (Expr) exp2;
 
 		Sort s1 = e1.getSort();
 		Sort s2 = e2.getSort();
 
-		// Int == Real  →  toReal(Int) == Real
+		// Int <-> Real
 		if (s1.equals(ctx.getIntSort()) && s2.equals(ctx.getRealSort())) {
-			e1 = ctx.mkInt2Real((IntExpr) e1);
+			if (e1 instanceof IntExpr) {
+				e1 = ctx.mkInt2Real((IntExpr) e1);
+			}
 		}
 		else if (s1.equals(ctx.getRealSort()) && s2.equals(ctx.getIntSort())) {
-			e2 = ctx.mkInt2Real((IntExpr) e2);
+			if (e2 instanceof IntExpr) {
+				e2 = ctx.mkInt2Real((IntExpr) e2);
+			}
 		}
 
-		return ctx.mkEq(e1, e2); // mkEq needs both args to be of the same type.
+		// Int <-> BitVector
+		else if (s1.equals(ctx.getIntSort()) && s2 instanceof BitVecSort) {
+			if (e1 instanceof IntExpr) {
+				BitVecSort bvSort = (BitVecSort) s2;
+				e1 = ctx.mkInt2BV(bvSort.getSize(), (IntExpr) e1);
+			}
+		}
+		else if (s1 instanceof BitVecSort && s2.equals(ctx.getIntSort())) {
+			if (e2 instanceof IntExpr) {
+				BitVecSort bvSort = (BitVecSort) s1;
+				e2 = ctx.mkInt2BV(bvSort.getSize(), (IntExpr) e2);
+			}
+		}
+		// We check if the sorts are unified before calling mkEq.
+		if (!e1.getSort().equals(e2.getSort())) {
+			throw new RuntimeException("## Error Z3 Sort Mismatch: Bridge failed to unify "
+					+ e1.getSort() + " and " + e2.getSort());
+		}
+		return ctx.mkEq(e1, e2);
 	}
 
     @Override
     public double getRealValueInf(Object dpVar) {
-        throw new RuntimeException("## Error Z3: getRealValueInf not implemented \n");//return 0;
+        throw new RuntimeException("## Error Z3: getRealValueInf not implemented in z3 solver \n");//return 0;
     }
 
 	@Override
 	public double getRealValueSup(Object dpVar) {
 		// TODO Auto-generated method stub
-	    throw new UnsupportedOperationException("## Error Z3: getRealValueSup not implemented \n");//return 0;
+	    throw new UnsupportedOperationException("## Error Z3: getRealValueSup not implemented in z3 solver \n");//return 0;
 	}
 
 	@Override
@@ -1113,7 +1147,7 @@ public class ProblemZ3 extends ProblemGeneral {
 	@Override
 	public void postLogicalOR(Object[] constraint) {
 		// TODO Auto-generated method stub
-		throw new RuntimeException("## Error Z3 : postLogicalOR not implemented\n");
+		throw new RuntimeException("## Error Z3 : postLogicalOR not implemented in solver z3\n");
 	}
 
     // Added by Aymeric to support arrays

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/numeric/solvers/ProblemZ3.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/numeric/solvers/ProblemZ3.java
@@ -976,7 +976,7 @@ public class ProblemZ3 extends ProblemGeneral {
 	@Override
 	public Object and(long value, Object exp) {
 		// hardcoded this to 64 because in config the bitvector length is set to 64
-		return ctx.mkBVAND(toBV(ctx, (Expr<?>) exp, 64), ctx.mkBV(value, 64));
+		return ctx.mkBVAND(toBV(ctx, (Expr<?>) exp, SymbolicInstructionFactory.bvlength), ctx.mkBV(value, SymbolicInstructionFactory.bvlength));
 	}
 
 	@Override

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/string/SymbolicStringConstraintsGeneral.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/string/SymbolicStringConstraintsGeneral.java
@@ -447,12 +447,7 @@ public class SymbolicStringConstraintsGeneral {
 		else if(solver.equals(Z3STR3)){
 			System.out.println("$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$");
 			System.out.println("Calling Z3str3\n");
-			 Output dpresult = null;
-			try{
-				dpresult = TranslateToZ3str3.solve(pc);
-			} catch (Exception e) {
-				return false;
-			}
+			Output dpresult = dpresult = TranslateToZ3str3.solve(pc);
 			constraintCount = constraintCount + 1;
 			return dpresult.isSAT();
 		}

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/string/SymbolicStringConstraintsGeneral.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/string/SymbolicStringConstraintsGeneral.java
@@ -447,7 +447,12 @@ public class SymbolicStringConstraintsGeneral {
 		else if(solver.equals(Z3STR3)){
 			System.out.println("$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$");
 			System.out.println("Calling Z3str3\n");
-			final Output dpresult = TranslateToZ3str3.solve(pc);
+			 Output dpresult = null;
+			try{
+				dpresult = TranslateToZ3str3.solve(pc);
+			} catch (Exception e) {
+				return false;
+			}
 			constraintCount = constraintCount + 1;
 			return dpresult.isSAT();
 		}

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/witness/Edge.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/witness/Edge.java
@@ -89,12 +89,25 @@ public class Edge{
             }
         }
 
-        else{ //TODO: be conservative and not generate a witness if we cannot find a solution for the symbolic variable, i.e., do not print default value.
-            // Here, the type of symbolic variable should be integer or char.
-            assert(symbolicVariableInfoList.get(indexOfEdge).returnType.equals("int") ||
-                    symbolicVariableInfoList.get(indexOfEdge).returnType.equals("char"));
-            if(symbolicVariableInfoList.get(indexOfEdge).varValue == null) edgeBuilder.append(String.format("         <data key=\"assumption\">%s == %d</data>\n", symbolicVariableInfoList.get(indexOfEdge).varPgmName, 4));
-            else edgeBuilder.append(String.format("         <data key=\"assumption\">%s == %s</data>\n", symbolicVariableInfoList.get(indexOfEdge).varPgmName, symbolicVariableInfoList.get(indexOfEdge).varValue));
+        else {
+            // Handle all integral types (int, long, short, byte, char)
+            String type = symbolicVariableInfoList.get(indexOfEdge).returnType;
+
+            // Check for long specifically or any other integral type
+            if(type.equals("int") || type.equals("long") || type.equals("char") ||
+                    type.equals("byte") || type.equals("short")) {
+
+                if(symbolicVariableInfoList.get(indexOfEdge).varValue == null) {
+                    edgeBuilder.append(String.format("         <data key=\"assumption\">%s == %d</data>\n",
+                            symbolicVariableInfoList.get(indexOfEdge).varPgmName, 4));
+                } else {
+                    edgeBuilder.append(String.format("         <data key=\"assumption\">%s == %s</data>\n",
+                            symbolicVariableInfoList.get(indexOfEdge).varPgmName,
+                            symbolicVariableInfoList.get(indexOfEdge).varValue));
+                }
+            } else {
+                System.err.println("## Warning: Unknown type in Witness Generation: " + type);
+            }
         }
 
         edgeBuilder.append(String.format("         <data key=\"assumption.scope\">java::L%s;</data>\n", assumptionScope));


### PR DESCRIPTION
## Why is this PR needed?
To tackle some of the regression bugs in #138 
## What was implemented?
- symbolic and.
- symbolic mixed.
- A helper method to handle bit vector casting, I had to add this due to cast1.yml, It uses the and (&) bitwise operator. Which was not implemented in sv-comp z3wrapper.
## Which bugs were addressed?
```
Now aligns with expected outcome:

jpf-regression/ExSymExeD2L_false witness validated
jpf-regression/ExSymExeD2L_true
jbmc-regression/cast1
jpf-regression/ExSymExeD2I_true
jpf-regression/ExSymExeF2I_false witness validated
jpf-regression/ExSymExeF2I_true
jpf-regression/ExSymExeF2L_false witness validated
jpf-regression/ExSymExeF2L_true
jdart-regression/double2long

From unknown to wrong flag:
ExSymExeI2D_true -> Used to flag unknown, but now results in unsafe, need to dig into what im doing wrong with doubles and integers, i suspect. any help here would be greatly appreciated!
```
## How was this tested?
Manually, using the jpf-sv-comp script in /SPF/ and the sv-benchmarks.
cases in which false was expected were validated with wit4java as per the instructions.

## Things to note:
Going over the code in ProblemZ3, i think before further debugging is to be done, a small change on how errors are thrown could be immensely helpful, there is an example in this commit, please refer to getRealValueSup method. if you agree, may i go ahead and make sure other similar methods throw more explicit errors for easier debugging.