### PR TITLE
Two-Pass Approach - Regression Bugs

### DIFF
--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/numeric/BitwiseDetector.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/numeric/BitwiseDetector.java
@@ -1,0 +1,42 @@
+package gov.nasa.jpf.symbc.numeric;
+
+public class BitwiseDetector extends ConstraintExpressionVisitor {
+    private boolean hasBitwise = false;
+
+    public boolean hasBitwise() {
+        return hasBitwise;
+    }
+
+    // Visit binary linear integer expressions
+    @Override
+    public void preVisit(BinaryLinearIntegerExpression expr) {
+        checkOperator(expr.getOp());
+    }
+
+    // Visit binary non-linear integer expressions (though bitwise ops are linear, we check anyway)
+    @Override
+    public void preVisit(BinaryNonLinearIntegerExpression expr) {
+        checkOperator(expr.op);
+    }
+
+    private void checkOperator(Operator op) {
+        if (!hasBitwise) {
+            switch (op) {
+                case AND:
+                case OR:
+                case XOR:
+                case SHIFTL:
+                case SHIFTR:
+                case SHIFTUR:
+                    hasBitwise = true;
+                    break;
+                default:
+                    // nothing
+            }
+        }
+    }
+
+    // The default visit order is:
+    //   preVisit(Constraint) -> left.accept(visitor) -> right.accept(visitor) -> postVisit
+    // So we are covered.
+}

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/numeric/SymbolicConstraintsGeneral.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/numeric/SymbolicConstraintsGeneral.java
@@ -74,16 +74,28 @@ public class SymbolicConstraintsGeneral {
             return false;
         }
 
-        // if (SymbolicInstructionFactory.debugMode)
-        // System.out.println("checking: PC "+pc);
-
         String[] dp = SymbolicInstructionFactory.dp;
+
+        // --- Two‑pass detection for Z3 ---
+        boolean useBitvectorForZ3 = false;
+        if (dp != null && dp.length > 0 && dp[0].equalsIgnoreCase("z3")) {
+            BitwiseDetector detector = new BitwiseDetector();
+            Constraint c = pc.header;
+            while (c != null) {
+                c.accept(detector);
+                if (detector.hasBitwise()) {
+                    useBitvectorForZ3 = true;
+                    break;
+                }
+                c = c.getTail();
+            }
+        }
+
+        // --- Solver selection ---
         if (dp == null) { // default: use choco
             pb = new ProblemChoco();
         } else if (dp[0].equalsIgnoreCase("choco")) {
             pb = new ProblemChoco();
-            // } else if(dp[0].equalsIgnoreCase("choco2")){
-            // pb = new ProblemChoco2();
         } else if (dp[0].equalsIgnoreCase("coral")) {
             pb = new ProblemCoral();
         } else if (dp[0].equalsIgnoreCase("iasolver")) {
@@ -95,7 +107,11 @@ public class SymbolicConstraintsGeneral {
         } else if (dp[0].equalsIgnoreCase("yices")) {
             pb = new ProblemYices();
         } else if (dp[0].equalsIgnoreCase("z3")) {
-            pb = new ProblemZ3();
+            if (useBitvectorForZ3) {
+                pb = new ProblemZ3BitVector();   // bitvector version for bitwise ops
+            } else {
+                pb = new ProblemZ3();             // plain arithmetic Z3
+            }
         } else if (dp[0].equalsIgnoreCase("z3inc")) {
             pb = new ProblemZ3Incremental();
         } else if (dp[0].equalsIgnoreCase("z3bitvectorinc")) {
@@ -161,7 +177,6 @@ public class SymbolicConstraintsGeneral {
         } else {
             return false;
         }
-
     }
 
     public boolean isSatisfiableGreen(PathCondition pc) {


### PR DESCRIPTION
## Issue
#138 
## Rational
When implementing more String support in commit cc80297, We have introduced a feature regression for bitwise operations, by defaulting to the standard z3 solver, the engine now attempts to solve bitwise operations (e.g., &, |, ^, <<, >>) using the Theory of Integers. and since these operations are not defined in the standard Integer theory (ProblemZ3), we are now failing multiple sv-benchmarks with unsoundness and Unknowns.

## Implementations:
- Added a priority mechanism, where we inspect the Path Condition (pc) before committing to a solver, such that if bitwise operations are detected, we prioritize z3bitvector to ensure mathematical correctness.

## Tradeoffs:
- This implementation assumes that we are not going to come accross mixed constraints involving bitwise operations and complex String operations.
A long-term fix would actually require a solver wrapper that can cast between Bit-Vectors and Integers (Theory Combination).

## Conclusion
Im keeping this as a draft for now, as i believe it is too naive of an approach at the moment and that its tradeoff is too costy, until we figure out their mixed constraints.

