### PR TITLE
Supporting RealExpr multiplication in Z3BitVector solver

### DIFF
--- a/src/main/gov/nasa/jpf/symbc/numeric/solvers/ProblemZ3BitVector.java
+++ b/src/main/gov/nasa/jpf/symbc/numeric/solvers/ProblemZ3BitVector.java
@@ -44,6 +44,7 @@ import java.util.concurrent.TimeUnit;
 import com.microsoft.z3.*;
 
 import gov.nasa.jpf.symbc.SymbolicInstructionFactory;
+import gov.nasa.jpf.symbc.numeric.RealExpression;
 
 public class ProblemZ3BitVector extends ProblemGeneral {
 
@@ -696,7 +697,12 @@ public class ProblemZ3BitVector extends ProblemGeneral {
                 return ctx.mkBVMul((BitVecExpr) exp1, (BitVecExpr) exp2);
             } else if (exp1 instanceof IntExpr && exp2 instanceof IntExpr) {
                 return ctx.mkMul((IntExpr) exp1, (IntExpr) exp2);
-            } else {
+            }
+            else if(exp1 instanceof RealExpr && exp2 instanceof RealExpr)
+            {
+                return ctx.mkMul((RealExpr) exp1,(RealExpr) exp2);
+            } 
+            else {
                 throw new RuntimeException();
             }
         } catch (Exception e) {

--- a/src/tests/gov/nasa/jpf/symbc/TestRealMultiplication.java
+++ b/src/tests/gov/nasa/jpf/symbc/TestRealMultiplication.java
@@ -1,0 +1,16 @@
+package gov.nasa.jpf.symbc;
+
+public class TestRealMultiplication {
+
+    public static void test(double x, double y) {
+        double z = x * y;
+
+        if (z == 10.0) {
+            assert false;
+        }
+    }
+
+    public static void main(String[] args) {
+        test(0,0);
+    }
+}

--- a/src/tests/gov/nasa/jpf/symbc/TestRealMultiplication.jpf
+++ b/src/tests/gov/nasa/jpf/symbc/TestRealMultiplication.jpf
@@ -1,0 +1,22 @@
+target=gov.nasa.jpf.symbc.TestRealMultiplication
+classpath=${jpf-symbc}/build/tests
+
+listener=.symbc.SymbolicListener
+
+symbolic.method=gov.nasa.jpf.symbc.TestRealMultiplication.test(sym#sym)
+
+symbolic.dp=z3bitvector
+symbolic.min_int=-2147483648
+symbolic.max_int=2147483647
+symbolic.min_double=-10000.0
+symbolic.max_double=10000.0
+symbolic.bvlength=64
+search.depth_limit=13
+symbolic.strings=true
+symbolic.string_dp=z3str3
+symbolic.lazy=on
+symbolic.jrarrays=true
+listener = .symbc.SymbolicListener
+
+symbolic.optimizechoices=true
+symbolic.debug=true


### PR DESCRIPTION
#109 

This Pull Request adds support for multiplication between **RealExpr** objects in Z3BitVector 

Earlier, multiplication between symbolic real expressions was not handled in 
ProblemZ3BitVector,which cause runtime failures such as:

Error Z3: **mult(Object, Object)** failed

Changes:
- Added RealExpr * RealExpr using ctx.mkMul in ProblemZ3BitVector

Changes on SV-COMP floating point benchmarks:
Fully solved:
- Optimization2
- Optimization6
- coral81
- coral84

Partially solved / improved support:
- Optimization4
- coral20
- coral21
- coral22
- coral26
- coral56
- coral57
- coral58
- coral59
- coral60
- coral9

Related to #109