### PR TITLE
RealExpr Division support in Z3BitVector

### DIFF
--- a/src/main/gov/nasa/jpf/symbc/numeric/solvers/ProblemZ3BitVector.java
+++ b/src/main/gov/nasa/jpf/symbc/numeric/solvers/ProblemZ3BitVector.java
@@ -746,6 +746,8 @@ public class ProblemZ3BitVector extends ProblemGeneral {
                 return ctx.mkBVSDiv((BitVecExpr) exp1, (BitVecExpr) exp2);
             } else if (exp1 instanceof IntExpr && exp2 instanceof IntExpr) {
                 return ctx.mkDiv((IntExpr) exp1, (IntExpr) exp2);
+            } else if(exp1 instanceof RealExpr && exp2 instanceof RealExpr) {
+                return ctx.mkDiv((RealExpr) exp1, (RealExpr) exp2);
             } else {
                 throw new RuntimeException();
             }

--- a/src/tests/gov/nasa/jpf/symbc/TestRealDivision.java
+++ b/src/tests/gov/nasa/jpf/symbc/TestRealDivision.java
@@ -1,0 +1,16 @@
+package gov.nasa.jpf.symbc;
+
+public class TestRealDivision {
+    public static void test(double x, double y) {
+
+        double z = x / y;
+
+        if (z == 5.0) {
+            assert false;
+        }
+    }
+
+    public static void main(String[] args) {
+        test(0, 0);
+    }
+}

--- a/src/tests/gov/nasa/jpf/symbc/TestRealDivision.jpf
+++ b/src/tests/gov/nasa/jpf/symbc/TestRealDivision.jpf
@@ -1,0 +1,21 @@
+target=gov.nasa.jpf.symbc.TestRealDivision
+classpath=${jpf-symbc}/build/tests
+
+listener=.symbc.SymbolicListener
+
+symbolic.method=gov.nasa.jpf.symbc.TestRealDivision.test(sym#sym)
+symbolic.dp=z3bitvector
+symbolic.min_int=-2147483648
+symbolic.max_int=2147483647
+symbolic.min_double=-10000.0
+symbolic.max_double=10000.0
+symbolic.bvlength=64
+search.depth_limit=13
+symbolic.strings=true
+symbolic.string_dp=z3str3
+symbolic.lazy=on
+symbolic.jrarrays=true
+listener = .symbc.SymbolicListener
+
+symbolic.optimizechoices=true
+symbolic.debug=true


### PR DESCRIPTION
Related to #109

Adding support for division earlier missing in div(Object,Object) for RealExpr in Z3BitVector.

Division between symbolic real expressions was not handled in ProblemZ3BitVector,
which lead to failures like:
Error Z3: div(Object, Object) failed

Changes:
Added RealExpr / RealExpr using ctx.mkDiv, after adding RealExpr division support,

they now progress further and fail at:
Math.sqrt, indicating the division issue has been resolved.
Support for operations such as Math.sqrt will be reflected in future updates.

Changes on SV-COMP floating point benchmarks:
Partially solved / improved support:

Optimization3
coral61
coral62
coral63
coral64
coral65
coral66

#109 