### PR TITLE
Peer support for Character.digit() and Character.forDigit()

### DIFF
--- a/src/examples/CharacterPeerTest.java
+++ b/src/examples/CharacterPeerTest.java
@@ -1,0 +1,32 @@
+import gov.nasa.jpf.vm.Verify;
+
+public class CharacterPeerTest {
+
+    public static void main(String[] args) {
+
+        int radix = Verify.getInt(2, 5);
+        int digit = Verify.getInt(0, 5);
+
+        char c = Character.forDigit(digit, radix);
+
+        if (c == 't') {
+            assert true;
+        }
+
+        char input = (char) Verify.getInt(0, 10);
+
+        int result = Character.digit(input, radix);
+
+        if (result == 5) {
+            assert true;
+        }
+
+        char check = (char) Verify.getInt(0, 10);
+
+        boolean defined = Character.isDefined(check);
+
+        if (defined) {
+            assert true;
+        }
+    }
+}

--- a/src/examples/CharacterPeerTest.jpf
+++ b/src/examples/CharacterPeerTest.jpf
@@ -1,0 +1,10 @@
+target=CharacterPeerTest
+classpath=${jpf-symbc}/build/examples
+
+listener=gov.nasa.jpf.symbc.SymbolicListener
+
+symbolic.dp=z3bitvector
+symbolic.bvlength=32
+
+search.depth_limit=10
+search.max_states=20

--- a/src/peers/gov/nasa/jpf/symbc/JPF_java_lang_Character.java
+++ b/src/peers/gov/nasa/jpf/symbc/JPF_java_lang_Character.java
@@ -1,0 +1,58 @@
+package gov.nasa.jpf.symbc;
+
+import gov.nasa.jpf.annotation.MJI;
+import gov.nasa.jpf.symbc.numeric.SymbolicInteger;
+import gov.nasa.jpf.vm.MJIEnv;
+import gov.nasa.jpf.vm.NativePeer;
+// Peer implementations for Character API methods used during symbolic execution
+public class JPF_java_lang_Character extends NativePeer {
+
+    @MJI
+    public boolean isDefined__C__Z(MJIEnv env, int clsObjRef, int c) {
+        Object[] attrs = env.getArgAttributes();
+        Object attr = (attrs != null) ? attrs[0] : null;
+
+        if (attr == null) {
+            return Character.isDefined((char) c);
+        }
+
+        SymbolicInteger sym = new SymbolicInteger("isDefined_" + attr);
+        env.setReturnAttribute(sym);
+
+        return false;
+    }
+
+    @MJI
+    public int digit__CI__I(MJIEnv env, int clsObjRef, int ch, int radix) {
+
+        Object[] attrs = env.getArgAttributes();
+
+        if (attrs == null || (attrs[0] == null && attrs[1] == null)) {
+            return Character.digit((char) ch, radix);
+        }
+
+        SymbolicInteger symResult =
+                new SymbolicInteger("digit_" + ch, -1, 35);
+
+        int result = Character.digit((char) ch, radix);
+        env.setReturnAttribute(symResult);
+        return result;
+    }
+
+    @MJI
+    public char forDigit__II__C(MJIEnv env, int clsObjRef, int digit, int radix) {
+
+        Object[] attrs = env.getArgAttributes();
+
+        if (attrs == null || (attrs[0] == null && attrs[1] == null)) {
+            return Character.forDigit(digit, radix);
+        }
+
+        SymbolicInteger symResult =
+                new SymbolicInteger("forDigit_" + digit + "_" + radix, 0, 65535);
+
+        char result = Character.forDigit(digit, radix);
+        env.setReturnAttribute(symResult);
+        return result;
+    }
+}


### PR DESCRIPTION
Additional String Support is Needed #108 
This PR adds peer implementations for Character API methods used during symbolic execution.

Implemented methods:
- Character.digit(char, int)
- Character.forDigit(int, int)

These peers allow symbolic inputs to be handled correctly without concretization during execution.

Related to #108