### PR TITLE
Support for String parsing APIs 

### DIFF
--- a/src/examples/DoubleParserDoublePeerTest.java
+++ b/src/examples/DoubleParserDoublePeerTest.java
@@ -1,0 +1,13 @@
+import org.sosy_lab.sv_benchmarks.Verifier;
+
+public class DoubleParserDoublePeerTest {
+
+  public static void main(String[] args) {
+
+    String s = Verifier.nondetString();
+
+    double d = Double.parseDouble(s);
+
+    assert true;
+  }
+}

--- a/src/examples/DoubleParserDoublePeerTest.jpf
+++ b/src/examples/DoubleParserDoublePeerTest.jpf
@@ -1,0 +1,10 @@
+target = DoubleParserDoublePeerTest
+
+classpath = ${jpf-symbc}/build/examples
+sourcepath = ${jpf-symbc}/src/examples
+
+symbolic.method = DoubleParserDoublePeerTest.main(sym)
+
+symbolic.dp = z3bitvector
+symbolic.string_dp = z3str3
+symbolic.string_dp_timeout_ms = 0

--- a/src/examples/FloatParserFloatPeerTest.java
+++ b/src/examples/FloatParserFloatPeerTest.java
@@ -1,0 +1,13 @@
+import org.sosy_lab.sv_benchmarks.Verifier;
+
+public class FloatParserFloatPeerTest {
+
+  public static void main(String[] args) {
+
+    String s = Verifier.nondetString();
+
+    float f = Float.parseFloat(s);
+
+    assert true;
+  }
+}

--- a/src/examples/FloatParserFloatPeerTest.jpf
+++ b/src/examples/FloatParserFloatPeerTest.jpf
@@ -1,0 +1,10 @@
+target = FloatParserFloatPeerTest
+
+classpath = ${jpf-symbc}/build/examples
+sourcepath = ${jpf-symbc}/src/examples
+
+symbolic.method = FloatParseFloatPeerTest.main(sym)
+
+symbolic.dp = z3bitvector
+symbolic.string_dp = z3str3
+symbolic.string_dp_timeout_ms = 0

--- a/src/peers/gov/nasa/jpf/symbc/JPF_java_lang_Double.java
+++ b/src/peers/gov/nasa/jpf/symbc/JPF_java_lang_Double.java
@@ -1,0 +1,15 @@
+package gov.nasa.jpf.symbc;
+
+import gov.nasa.jpf.annotation.MJI;
+import gov.nasa.jpf.vm.MJIEnv;
+import gov.nasa.jpf.vm.NativePeer;
+
+// Peer for Double.parseDouble(String) to support symbolic execution
+public class JPF_java_lang_Double extends NativePeer {
+
+    @MJI
+    public double parseDouble__Ljava_lang_String_2__D(MJIEnv env, int clsRef, int strRef) {
+
+        return 0.0;
+    }
+}

--- a/src/peers/gov/nasa/jpf/symbc/JPF_java_lang_Float.java
+++ b/src/peers/gov/nasa/jpf/symbc/JPF_java_lang_Float.java
@@ -1,0 +1,20 @@
+package gov.nasa.jpf.symbc;
+
+import gov.nasa.jpf.annotation.MJI;
+import gov.nasa.jpf.vm.MJIEnv;
+import gov.nasa.jpf.vm.NativePeer;
+import gov.nasa.jpf.symbc.numeric.SymbolicReal;
+
+// Peer for Float.parseFloat(String) to support symbolic execution
+public class JPF_java_lang_Float extends NativePeer {
+
+    @MJI
+    public float parseFloat__Ljava_lang_String_2__F(MJIEnv env, int clsRef, int strRef) {
+
+        SymbolicReal sym = new SymbolicReal("sym_float");
+
+        env.setReturnAttribute(sym);
+
+        return 0.0f;
+    }
+}


### PR DESCRIPTION

This PR adds peer stubs for String-based numeric parsing methods

These peers prevent symbolic strings from being concretized by the JVM parsing logic during symbolic execution.

Related to