### PR TITLE
Symbolic support for compareTo in Strings

### DIFF
--- a/jpf-symbc/src/examples/CompareToTest.java
+++ b/jpf-symbc/src/examples/CompareToTest.java
@@ -1,0 +1,16 @@
+import gov.nasa.jpf.symbc.Debug;
+
+public class CompareToTest {
+
+    public static void main(String[] args) {
+
+        String a = Debug.makeSymbolicString("a");
+        String b = Debug.makeSymbolicString("b");
+
+        int r = a.compareTo(b);
+
+        if (r < 0) {
+            assert false;
+        }
+    }
+}

--- a/jpf-symbc/src/examples/CompareToTest.jpf
+++ b/jpf-symbc/src/examples/CompareToTest.jpf
@@ -1,0 +1,18 @@
+target=CompareToTest
+classpath=${jpf-symbc}/build/examples
+
+symbolic.dp=z3bitvector
+symbolic.min_int=-2147483648
+symbolic.max_int=2147483647
+symbolic.min_double=-10000.0
+symbolic.max_double=10000.0
+symbolic.bvlength=64
+search.depth_limit=13
+symbolic.strings=true
+symbolic.string_dp=z3str3
+symbolic.lazy=on
+symbolic.jrarrays=true
+listener = .symbc.SymbolicListener
+
+symbolic.optimizechoices=true
+symbolic.debug=true

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/bytecode/SymbolicStringHandler.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/bytecode/SymbolicStringHandler.java
@@ -66,13 +66,6 @@ import gov.nasa.jpf.vm.VM;
 import gov.nasa.jpf.vm.StackFrame;
 import gov.nasa.jpf.vm.ThreadInfo;
 import gov.nasa.jpf.jvm.bytecode.JVMInvokeInstruction;
-import gov.nasa.jpf.symbc.mixednumstrg.SpecialRealExpression;
-import gov.nasa.jpf.symbc.numeric.IntegerConstant;
-import gov.nasa.jpf.symbc.numeric.PCChoiceGenerator;
-import gov.nasa.jpf.symbc.numeric.Expression;
-import gov.nasa.jpf.symbc.numeric.IntegerExpression;
-import gov.nasa.jpf.symbc.numeric.RealExpression;
-import gov.nasa.jpf.symbc.numeric.PathCondition;
 import gov.nasa.jpf.symbc.string.*;
 import gov.nasa.jpf.symbc.mixednumstrg.*;
 
@@ -374,7 +367,18 @@ public class SymbolicStringHandler {
                     handleToLowerCase(invInst, th);
                     return invInst.getNext(th);
                 }
-            } else {
+            } else if (shortName.equals("compareTo")) { //compareTo added 
+					ChoiceGenerator<?> cg;
+					if (!th.isFirstStepInsn()) {
+						cg = new PCChoiceGenerator(3); //3 choices begin given <0 , =0, >0
+						th.getVM().setNextChoiceGenerator(cg);
+						return invInst;
+					} else {
+						handleCompareTo(invInst, th);
+						return invInst.getNext(th);
+					}
+				}
+				else {
 				throw new RuntimeException("ERROR: symbolic method not handled: " + shortName);
 				//return null;
 			}
@@ -385,7 +389,43 @@ public class SymbolicStringHandler {
 
 	}
 
+	private void handleCompareTo(JVMInvokeInstruction invInst, ThreadInfo th) {
 
+		StackFrame sf = th.getModifiableTopFrame();
+		Expression sym_v1 = (Expression) sf.getOperandAttr(1);
+		Expression sym_v2 = (Expression) sf.getOperandAttr(0);
+
+		// retrieving choice generated in 1st step
+		PCChoiceGenerator cg =
+			th.getVM().getSystemState().getLastChoiceGeneratorOfType(PCChoiceGenerator.class);
+		int choice = cg.getNextChoice();
+		PathCondition pc = PathCondition.getPC(th.getVM());
+		if (pc == null) pc = new PathCondition();
+
+		sf.pop(); // arg
+		sf.pop(); // receiver
+
+		// symbolic integer representing result of compareTo
+		SymbolicInteger res = new SymbolicInteger("compareTo_res");
+
+		// Possible paths exploration
+		if (choice == 0) {
+			pc._addDet(Comparator.LT, res, new IntegerConstant(0)); // result < 0
+			sf.push(-1, true);
+		} else if (choice == 1) {
+			pc._addDet(Comparator.EQ, res, new IntegerConstant(0)); // result == 0
+			sf.push(0, true);
+		} else {
+			pc._addDet(Comparator.GT, res, new IntegerConstant(0)); // result > 0
+			sf.push(1, true);
+		}
+
+		if (!pc.simplify()) {
+			th.getVM().getSystemState().setIgnored(true);
+		} else {
+			cg.setCurrentPC(pc);
+		}
+	}
   public void handleToUpperCase(JVMInvokeInstruction invInst,  ThreadInfo th) {
 
     StackFrame sf = th.getModifiableTopFrame();


### PR DESCRIPTION
#108
These change adds support for symbolic execution of String.compareTo in
SymbolicStringHandler.
This PR adds supports for String.compareTo missing earlier as observed in sv-benchmarks in jbmc-regression/StringCompare04.yml
resulting in  UNKNOWN
After changes it points to UNSAFE (verifiable in StringCompare04.yml)

A PCChoiceGenerator with three choices is introduced to represent the
possible outcomes of compareTo:
- result < 0
- result == 0
- result > 0