### PR TITLE
Add support for StringBuilder.capacity() method

### DIFF
--- a/jpf-symbc/src/examples/StringBuilderCapacityTest.java
+++ b/jpf-symbc/src/examples/StringBuilderCapacityTest.java
@@ -1,0 +1,12 @@
+/*
+ * Simple example to test symbolic handling of StringBuilder.capacity()
+ */
+import org.sosy_lab.sv_benchmarks.Verifier;
+
+public class StringBuilderCapacityTest {
+  public static void main(String[] args) {
+    StringBuilder buffer = new StringBuilder(Verifier.nondetString());
+    // this assertion forces JPF to explore capacity-related constraints
+    assert buffer.capacity() == 69;
+  }
+}

--- a/jpf-symbc/src/examples/StringBuilderCapacityTest.jpf
+++ b/jpf-symbc/src/examples/StringBuilderCapacityTest.jpf
@@ -1,0 +1,21 @@
+target=StringBuilderCapacityTest
+
+classpath=${jpf-symbc}/build/examples
+
+vm.peer_packages = gov.nasa.jpf.symbc
+
+symbolic.dp=z3bitvector
+symbolic.min_int=-2147483648
+symbolic.max_int=2147483647
+symbolic.min_double=-10000.0
+symbolic.max_double=10000.0
+symbolic.bvlength=64
+search.depth_limit=13
+symbolic.strings=true
+symbolic.string_dp=z3str3
+symbolic.lazy=on
+symbolic.jrarrays=true
+listener = gov.nasa.jpf.symbc.SymbolicListener
+
+symbolic.optimizechoices=true
+symbolic.debug=true

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/bytecode/SymbolicStringHandler.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/bytecode/SymbolicStringHandler.java
@@ -218,6 +218,8 @@ public class SymbolicStringHandler {
 				}
 			} else if (shortName.equals("length")) {
 				handleLength(invInst, th);
+			} else if (shortName.equals("capacity")) {
+				handleCapacity(invInst, th);
 			} else if (shortName.equals("indexOf")) {
 				handleIndexOf(invInst, th);
 			} else if (shortName.equals("lastIndexOf")) {
@@ -385,6 +387,29 @@ public class SymbolicStringHandler {
 
 	}
 
+	public void handleCapacity(JVMInvokeInstruction invInst, ThreadInfo th) {
+		StackFrame sf = th.getModifiableTopFrame();
+		Object sym_v1 = sf.getOperandAttr(0);
+		if (sym_v1 == null) {
+			return;
+		}
+
+		IntegerExpression lengthExpr = null;
+		if (sym_v1 instanceof SymbolicStringBuilder) {
+			lengthExpr = ((SymbolicStringBuilder) sym_v1)._length();
+			IntegerExpression capExpr = new gov.nasa.jpf.symbc.numeric.BinaryLinearIntegerExpression(lengthExpr, gov.nasa.jpf.symbc.numeric.Operator.PLUS, new IntegerConstant(16));
+			sf.pop();
+			sf.push(0, false);
+			sf.setOperandAttr(capExpr);
+		} else if (sym_v1 instanceof StringSymbolic) {
+			lengthExpr = ((StringExpression) sym_v1)._length();
+			sf.pop();
+			sf.push(0, false);
+			sf.setOperandAttr(lengthExpr);
+		} else {
+			return;
+		}
+	}
 
   public void handleToUpperCase(JVMInvokeInstruction invInst,  ThreadInfo th) {
 


### PR DESCRIPTION
Added `handleCapacity()` method in `SymbolicStringHandler.java` that:
- Retrieves the symbolic length of the StringBuilder
- Calculates capacity using the formula: `length + 16` (as per Java's StringBuilder specification for `StringBuilder(String s)` constructor)
- Pushes the resulting symbolic integer expression onto the stack

Relates to #108 (jbmc-regression/StringBuilderCapLen04.yml)