### PR TITLE
Support for Character.digit, Character.forDigit and java.lang.Character

### DIFF
--- a/jpf-symbc/src/classes/java/util/Scanner.java
+++ b/jpf-symbc/src/classes/java/util/Scanner.java
@@ -10,9 +10,17 @@ import gov.nasa.jpf.symbc.Debug;
 public class Scanner {
 
   public Scanner(InputStream in) { }
-  
+  public Scanner(String s) { }
   private static int symid = 0;
   public String nextLine() {
     return Debug.makeSymbolicString("SCAN_SYM_" + symid++);
   } 
+  //ADDED
+  public int nextInt() {
+    return Debug.makeSymbolicInteger("SCAN_INT_" + symid++);
+  }
+  public String next() {
+    return Debug.makeSymbolicString("SCAN_STR_" + symid++);
+    
+  }
 }

--- a/jpf-symbc/src/examples/TestCharAndStringValue.java
+++ b/jpf-symbc/src/examples/TestCharAndStringValue.java
@@ -1,0 +1,23 @@
+import gov.nasa.jpf.symbc.Debug;
+
+public class TestCharAndStringValue {
+
+    // Test for StaticCharMethods06
+    public static void testGetNumericValue() {
+        char c = Debug.makeSymbolicChar("c");
+
+        //numeric behavior for digits
+        int numeric = c - '0';
+
+        //valid digit range
+        if (c >= '0' && c <= '9') {
+            if (numeric < 0 || numeric > 9) {
+                assert false;
+            }
+        }
+    }
+
+    public static void main(String[] args) {
+        testGetNumericValue();
+    }
+}

--- a/jpf-symbc/src/examples/TestCharAndStringValue.jpf
+++ b/jpf-symbc/src/examples/TestCharAndStringValue.jpf
@@ -1,0 +1,17 @@
+target=TestCharAndStringValue
+classpath=${jpf-symbc}/build/examples
+sourcepath=${jpf-symbc}/src/examples
+symbolic.dp=z3bitvector
+symbolic.min_int=-2147483648
+symbolic.max_int=2147483647
+
+symbolic.strings=true
+symbolic.string_dp=z3str3
+
+symbolic.lazy=on
+symbolic.jrarrays=true
+
+listener = .symbc.SymbolicListener
+
+symbolic.optimizechoices=true
+symbolic.debug=true

--- a/jpf-symbc/src/examples/TestDigitHandler.java
+++ b/jpf-symbc/src/examples/TestDigitHandler.java
@@ -1,0 +1,18 @@
+import gov.nasa.jpf.symbc.Debug;
+
+public class TestDigitHandler {
+
+    public static void testDigitHandler() {
+        int radix = Debug.makeSymbolicInteger("radix");
+        char c = Debug.makeSymbolicChar("c");
+        if (radix < 2 || radix > 36) return;
+        int d = Character.digit(c, radix);
+        if (d == 5) {
+            assert false;
+        }
+    }
+
+    public static void main(String[] args) {
+        testDigitHandler();
+    }
+}

--- a/jpf-symbc/src/examples/TestDigitHandler.jpf
+++ b/jpf-symbc/src/examples/TestDigitHandler.jpf
@@ -1,0 +1,20 @@
+target=TestDigitHandler
+classpath=${jpf-symbc}/build/examples
+sourcepath=${jpf-symbc}/src/examples
+
+symbolic.method=TestDigitHandler.testDigitHandler()
+
+symbolic.dp=z3bitvector
+symbolic.min_int=-2147483648
+symbolic.max_int=2147483647
+
+symbolic.strings=true
+symbolic.string_dp=z3str3
+
+symbolic.lazy=on
+symbolic.jrarrays=true
+
+listener = .symbc.SymbolicListener
+
+symbolic.optimizechoices=true
+symbolic.debug=true

--- a/jpf-symbc/src/examples/TestForDigit.java
+++ b/jpf-symbc/src/examples/TestForDigit.java
@@ -1,0 +1,22 @@
+import gov.nasa.jpf.symbc.Debug;
+
+public class TestForDigit {
+
+    public static void testForDigit() {
+         int radix = Debug.makeSymbolicInteger("radix");
+        int digit = Debug.makeSymbolicInteger("digit");
+
+        if (radix < 2 || radix > 36) return;
+        if (digit < 0 || digit >= radix) return;
+
+       char c = Character.forDigit(digit, radix);
+
+        if (c == 0) {
+            assert false;
+        }
+    }
+
+    public static void main(String[] args) {
+        testForDigit();
+    }
+}

--- a/jpf-symbc/src/examples/TestForDigit.jpf
+++ b/jpf-symbc/src/examples/TestForDigit.jpf
@@ -1,0 +1,21 @@
+target=TestForDigit
+classpath=${jpf-symbc}/build/examples
+sourcepath=${jpf-symbc}/src/examples
+
+symbolic.method=TestForDigit.testCharDigit()
+
+symbolic.dp=z3bitvector
+symbolic.min_int=-2147483648
+symbolic.max_int=2147483647
+
+symbolic.strings=true
+symbolic.string_dp=z3str3
+
+symbolic.lazy=on
+symbolic.jrarrays=true
+search.depth_limit=10
+symbolic.optimizechoices=true
+listener = .symbc.SymbolicListener
+
+symbolic.optimizechoices=true
+symbolic.debug=true

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/bytecode/SymbolicStringHandler.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/bytecode/SymbolicStringHandler.java
@@ -367,7 +367,27 @@ public class SymbolicStringHandler {
                     handleToLowerCase(invInst, th);
                     return invInst.getNext(th);
                 }
-            } else {
+            } else if (shortName.equals("forDigit")) { // handles Character.forDigit symbolic execution
+				ChoiceGenerator<?>cg;
+				if (!th.isFirstStepInsn()) {
+					cg =new PCChoiceGenerator(1);
+					th.getVM().setNextChoiceGenerator(cg);
+					return invInst;
+				} else {
+					handleForDigit(invInst, th );//symbolic handling logic
+					return invInst.getNext(th );
+				}
+			} else if (shortName.equals("digit")) { //handles Character.digit symbolic execution
+					ChoiceGenerator<?> cg;
+					if (!th.isFirstStepInsn()) {
+						cg = new PCChoiceGenerator(1);
+						th.getVM().setNextChoiceGenerator(cg);
+						return invInst;
+					} else {
+						handleDigit(invInst , th); //digit handling logic
+						return invInst.getNext(th);
+					}
+				} else {
 				throw new RuntimeException("ERROR: symbolic method not handled: " + shortName);
 				//return null;
 			}
@@ -378,6 +398,81 @@ public class SymbolicStringHandler {
 
 	}
 
+	private void handleForDigit(JVMInvokeInstruction invInst, ThreadInfo th) {
+    StackFrame sf = th.getModifiableTopFrame();
+    IntegerExpression sym_radix =(IntegerExpression) sf.getOperandAttr(0);
+    IntegerExpression sym_digit= (IntegerExpression) sf.getOperandAttr(1);
+    sf.pop(2);
+
+    ChoiceGenerator<?> cg=th.getVM().getChoiceGenerator();
+    assert (cg instanceof PCChoiceGenerator);
+
+    PathCondition pc;
+    ChoiceGenerator<?> prev= cg.getPreviousChoiceGenerator();
+    while (prev != null && !(prev instanceof PCChoiceGenerator)) {
+        prev = prev.getPreviousChoiceGenerator();
+    }
+
+    pc = (prev == null) ?new PathCondition() : ((PCChoiceGenerator) prev).getCurrentPC();
+    assert pc != null;// sanity check
+
+    // Constraints: valid digit + radix
+    pc._addDet(Comparator.GE,sym_digit, new IntegerConstant(0)); // digit >= 0
+    pc._addDet(Comparator.GE,sym_radix, new IntegerConstant(2));// radix >= 2
+    pc._addDet(Comparator.LE, sym_radix,new IntegerConstant(36)); //radix<=36 
+    pc._addDet(Comparator.LT, sym_digit,sym_radix);
+
+    if (!pc.simplify()) {
+        th.getVM().getSystemState().setIgnored(true);
+        return;
+    }
+
+    ((PCChoiceGenerator) cg).setCurrentPC(pc);
+
+    // symbolic result
+    IntegerExpression result=new SymbolicInteger("forDigit_res");
+
+    sf.push(0, false);
+    sf.setOperandAttr(result);
+}
+
+private void handleDigit(JVMInvokeInstruction invInst, ThreadInfo th) {
+    StackFrame sf = th.getModifiableTopFrame();
+
+    IntegerExpression sym_radix= (IntegerExpression) sf.getOperandAttr(0);// symbolic radix
+    IntegerExpression sym_char =(IntegerExpression) sf.getOperandAttr(1);
+
+    sf.pop(2);
+
+    ChoiceGenerator<?> cg =th.getVM().getChoiceGenerator();
+    assert (cg instanceof PCChoiceGenerator);
+
+    PathCondition pc;
+    ChoiceGenerator<?> prev = cg.getPreviousChoiceGenerator();
+    while (prev != null && !(prev instanceof PCChoiceGenerator)) {
+        prev = prev.getPreviousChoiceGenerator();
+    }
+
+    pc = (prev == null) ? new PathCondition(): ((PCChoiceGenerator) prev).getCurrentPC();
+    assert pc != null;
+
+    // radix constraints
+    pc._addDet(Comparator.GE, sym_radix, new IntegerConstant(2));// radix >= 2
+    pc._addDet(Comparator.LE, sym_radix, new IntegerConstant(36)); // radix <= 36
+
+    if (!pc.simplify()) {
+        th.getVM().getSystemState().setIgnored(true);
+        return;
+    }
+
+    ((PCChoiceGenerator) cg).setCurrentPC(pc);
+
+    // symbolic result (digit or -1)
+    IntegerExpression result = new SymbolicInteger("digit_res");
+
+    sf.push(0, false);
+    sf.setOperandAttr(result);
+}
 
   public void handleToUpperCase(JVMInvokeInstruction invInst,  ThreadInfo th) {
 

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/bytecode/SymbolicStringHandler.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/bytecode/SymbolicStringHandler.java
@@ -66,13 +66,6 @@ import gov.nasa.jpf.vm.VM;
 import gov.nasa.jpf.vm.StackFrame;
 import gov.nasa.jpf.vm.ThreadInfo;
 import gov.nasa.jpf.jvm.bytecode.JVMInvokeInstruction;
-import gov.nasa.jpf.symbc.mixednumstrg.SpecialRealExpression;
-import gov.nasa.jpf.symbc.numeric.IntegerConstant;
-import gov.nasa.jpf.symbc.numeric.PCChoiceGenerator;
-import gov.nasa.jpf.symbc.numeric.Expression;
-import gov.nasa.jpf.symbc.numeric.IntegerExpression;
-import gov.nasa.jpf.symbc.numeric.RealExpression;
-import gov.nasa.jpf.symbc.numeric.PathCondition;
 import gov.nasa.jpf.symbc.string.*;
 import gov.nasa.jpf.symbc.mixednumstrg.*;
 
@@ -1771,7 +1764,20 @@ public class SymbolicStringHandler {
 				} else { // converting int to Integer
 					handleParseBooleanValueOf(invInst, th);
 				}
-			} else {
+			} else if (cname.equals("java.lang.Character")) { //added missing Character support here
+				if (!(argTypes[0].equals("char"))){ // converting String → Character
+					ChoiceGenerator<?>cg;
+					if (!th.isFirstStepInsn()) {
+						cg =new PCChoiceGenerator(2);
+						th.getVM().setNextChoiceGenerator(cg );
+						return invInst;
+					} else {
+						handleParseCharValueOf(invInst,th );
+					}
+				} else { // converting char → Character
+					return handleCharValueOf(invInst, th);
+					}
+				} else {
 				throw new RuntimeException("ERROR: Type not handled in Symbolic Type ValueOf: " + cname);
 			}
 		}
@@ -1828,6 +1834,29 @@ public class SymbolicStringHandler {
 		}
 	}
 
+	private void handleParseCharValueOf(JVMInvokeInstruction invInst, ThreadInfo th) {
+		StackFrame sf = th.getModifiableTopFrame();
+		Expression sym_v1 = (Expression) sf.getOperandAttr(0); // get symbolic attribute of argument
+
+		if (sym_v1 == null) {
+			throw new RuntimeException("ERROR: symbolic method must have symbolic string operand");
+		} else {
+			if (sym_v1 instanceof IntegerExpression) {
+				IntegerExpression sym=(IntegerExpression) sym_v1; // cast to integer symbolic
+				sf.pop();
+				int objRef =getNewObjRef(invInst, th);
+				sf.push(objRef , true);
+
+				sf.setOperandAttr(sym);
+			} else {
+				sf.pop();
+				int objRef = getNewObjRef(invInst, th);
+				sf.push(objRef, true); 
+			}
+		}
+	}
+
+	
 	public void handleParseLongValueOf(JVMInvokeInstruction invInst,  ThreadInfo th) {
 		StackFrame sf = th.getModifiableTopFrame();
 		Expression sym_v3 = (Expression) sf.getOperandAttr(0);


### PR DESCRIPTION
#108 
Issue 1: java.lang.Character support

Adds missing symbolic support for java.lang.Character in valueOf handling.
Enables proper handling of char ↔ Character conversions in symbolic execution.
Fix for jbmc-regression/StaticCharMethods06.yml

java.lang.Character support needed for proper handling of Character.digit and Character.forDigit

Issue 2: Character.digit / Character.forDigit

Adding symbolic handling for Character.digit and Character.forDigit with minimal tests
Fix for jbmc-regression/StaticCharMethods05.yml

Witness validated for both and meets sv-benchmarks requirements.
Each commit can be used to differentiate and pinpoint fixes for better understanding 