### PR TITLE
Adding symbolic operand for handleLongValueOf and removing unsupported String operation

### DIFF
--- a/jpf-symbc/src/examples/TestStringValueOf07.java
+++ b/jpf-symbc/src/examples/TestStringValueOf07.java
@@ -1,0 +1,17 @@
+import org.sosy_lab.sv_benchmarks.Verifier;
+
+public class TestStringValueOf07 {
+
+  public static void check(long x) {
+    String s = String.valueOf(x);
+
+    if (x == 100000000000L) {
+      assert false;
+    }
+  }
+
+  public static void main(String[] args) {
+    long x = Verifier.nondetLong();
+    check(x);
+  }
+}

--- a/jpf-symbc/src/examples/TestStringValueOf07.jpf
+++ b/jpf-symbc/src/examples/TestStringValueOf07.jpf
@@ -1,0 +1,27 @@
+target=TestStringValueOf07
+
+classpath=${jpf-symbc}/build/examples
+
+symbolic.method=TestStringValueOf07.check(sym)
+
+symbolic.dp=z3bitvector
+symbolic.string_dp=z3str3
+
+symbolic.min_int=-2147483648
+symbolic.max_int=2147483647
+
+symbolic.min_double=-10000.0
+symbolic.max_double=10000.0
+
+symbolic.bvlength=64
+
+symbolic.strings=true
+symbolic.lazy=on
+symbolic.jrarrays=true
+
+search.depth_limit=13
+
+listener = .symbc.SymbolicListener
+
+symbolic.optimizechoices=true
+symbolic.debug=true

--- a/jpf-symbc/src/examples/TestStringValueOf09.java
+++ b/jpf-symbc/src/examples/TestStringValueOf09.java
@@ -1,0 +1,19 @@
+import gov.nasa.jpf.symbc.Debug;
+
+public class TestStringValueOf09 {
+
+    public static void test() {
+        String s = Debug.makeSymbolicString("s");
+
+        double d = Double.parseDouble(s);
+        String t = String.valueOf(d);
+
+        if (s.equals("abc")) {
+            assert false;
+        }
+    }
+
+    public static void main(String[] args) {
+        test();
+    }
+}

--- a/jpf-symbc/src/examples/TestStringValueOf09.jpf
+++ b/jpf-symbc/src/examples/TestStringValueOf09.jpf
@@ -1,0 +1,19 @@
+target=TestStringValueOf09
+
+classpath=${jpf-symbc}/build/examples
+sourcepath=${jpf-symbc}/src/examples
+
+symbolic.dp=z3bitvector
+symbolic.min_int=-2147483648
+symbolic.max_int=2147483647
+
+symbolic.strings=true
+symbolic.string_dp=z3str3
+
+symbolic.lazy=on
+symbolic.jrarrays=true
+
+listener = .symbc.SymbolicListener
+
+symbolic.optimizechoices=true
+symbolic.debug=true

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/bytecode/SymbolicStringHandler.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/bytecode/SymbolicStringHandler.java
@@ -284,9 +284,9 @@ public class SymbolicStringHandler {
 				if (!th.isFirstStepInsn()) { // first time around
 					cg = new PCChoiceGenerator(2);
 					th.getVM().setNextChoiceGenerator(cg);
-          			throw new RuntimeException("ERROR: Unsupported string operation.");
+          			// throw new RuntimeException("ERROR: Unsupported string operation.");
           //SH: commented this for now as this is not correctly working with Z3Str3.
-//					return invInst;
+					return invInst;
 				} else {
 					handleParseDouble(invInst, th);
 					return invInst.getNext(th);
@@ -2261,7 +2261,8 @@ public class SymbolicStringHandler {
 				cg = th.getVM().getChoiceGenerator();
 
 				assert (cg instanceof PCChoiceGenerator) : "expected PCChoiceGenerator, got: " + cg;
-				conditionValue = (Integer) cg.getNextChoice() == 0 ? false : true;
+				conditionValue = ((PCChoiceGenerator) cg).getNextChoice() == 1; //added
+
 				sf.pop();
 				PathCondition pc;
 
@@ -2284,8 +2285,8 @@ public class SymbolicStringHandler {
 					} else {
 						((PCChoiceGenerator) cg).setCurrentPC(pc);
 						RealExpression sym_v2 = new SpecialRealExpression(sym_v1);
-						sf.pushLong((long) 0); /* Result is don't care and 0 */
-						//sf = th.getModifiableTopFrame(); ??
+						// sf.pushLong((long) 0); /* Result is don't care and 0 */
+						 sf.pushDouble(0.0); //added
 						sf.setLongOperandAttr(sym_v2);
 					}
 				} else {
@@ -2293,8 +2294,8 @@ public class SymbolicStringHandler {
 					if (!pc.simplify()) {// not satisfiable
 						th.getVM().getSystemState().setIgnored(true);
 					} else {
-						throw new RuntimeException("ERROR: Double Format Type Exception");
-						//th.getVM().getSystemState().setIgnored(true);TODO: needs revision
+						th.getVM().getSystemState().setIgnored(true); //added
+
 					}
 				}
 			}
@@ -2514,8 +2515,13 @@ public class SymbolicStringHandler {
 		RealExpression sym_v1 = (RealExpression) sf.getOperandAttr(0);
 
 		if (sym_v1 == null) {
-			throw new RuntimeException("ERROR: symbolic string method must have symbolic operand: handleDoubleValueOf");
-		} else {
+        double val = Types.longToDouble(sf.peekLong());
+        sf.popLong();
+
+        int objRef = th.getHeap().newString(Double.toString(val), th).getObjectRef();
+        sf.push(objRef, true);
+        sf.setOperandAttr(null);
+    }  else {
 			sf.popLong();
 			StringExpression sym_v2 = StringExpression._valueOf(sym_v1);
 			int objRef = th.getHeap().newString("", th).getObjectRef(); /*

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/bytecode/SymbolicStringHandler.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/bytecode/SymbolicStringHandler.java
@@ -66,13 +66,6 @@ import gov.nasa.jpf.vm.VM;
 import gov.nasa.jpf.vm.StackFrame;
 import gov.nasa.jpf.vm.ThreadInfo;
 import gov.nasa.jpf.jvm.bytecode.JVMInvokeInstruction;
-import gov.nasa.jpf.symbc.mixednumstrg.SpecialRealExpression;
-import gov.nasa.jpf.symbc.numeric.IntegerConstant;
-import gov.nasa.jpf.symbc.numeric.PCChoiceGenerator;
-import gov.nasa.jpf.symbc.numeric.Expression;
-import gov.nasa.jpf.symbc.numeric.IntegerExpression;
-import gov.nasa.jpf.symbc.numeric.RealExpression;
-import gov.nasa.jpf.symbc.numeric.PathCondition;
 import gov.nasa.jpf.symbc.string.*;
 import gov.nasa.jpf.symbc.mixednumstrg.*;
 
@@ -2495,8 +2488,13 @@ public class SymbolicStringHandler {
 		StackFrame sf = th.getModifiableTopFrame();
 		IntegerExpression sym_v1 = (IntegerExpression) sf.getOperandAttr(0);
 
-		if (sym_v1 == null) {
-			throw new RuntimeException("ERROR: symbolic string method must have symbolic operand: handleLongValueOf");
+		if (sym_v1 == null) { //added fixes string
+			long val =sf.popLong();
+			StringExpression sym_v2=new StringConstant(String.valueOf(val));
+
+			int objRef = th.getHeap().newString("", th ).getObjectRef();
+			sf.push(objRef, true );
+			sf.setOperandAttr(sym_v2 );
 		} else {
 			sf.popLong();
 			StringExpression sym_v2 = StringExpression._valueOf(sym_v1);
@@ -2508,7 +2506,7 @@ public class SymbolicStringHandler {
 			sf.push(objRef, true);
 			sf.setOperandAttr(sym_v2);
 		}
-		return null;
+		return invInst.getNext(th);
 	}
 
 	public Instruction handleDoubleValueOf(JVMInvokeInstruction invInst, ThreadInfo th) {


### PR DESCRIPTION
#108
Issue 1: required symbolic operand → crash:handleLongValueOf
Fixes: handleLongValueOf (String.valueOf(long))
Fix: added concrete fallback for long → string conversion
File:jbmc-regression/StringValueOf07.yml


Issue 2: unsupported string operation exception
incorrect double handling (pushLong instead of pushDouble)
Fix:
removed unsupported exception
corrected double handling
File:jbmc-regression/StringValueOf09.yml

Witness validated for both and meets sv-benchmarks requirements.
#108
Each commit can be used to differentiate and pinpoint fixes for better understanding 